### PR TITLE
feat(search): add algolia search

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -103,6 +103,11 @@ const siteConfig = {
   scrollToTop: true,
   scrollToTopOptions: {
     zIndex: 100,
+  },
+
+  algolia: {
+    apiKey: '651f9d1e5d32c2a465935a001a047407',
+    indexName: 'meshcloud_dev'
   }
 };
 


### PR DESCRIPTION
Add algolia search for documentation. apiKey apparently does not have to be kept secret (example from official docusaurus config https://github.com/facebook/docusaurus/blob/1c032a0bd95b7c95e1985ff104d43416c16714e1/website/docusaurus.config.js#L74)