### PR TITLE
feat(access): adapt document around access control

### DIFF
--- a/docs/administration.index.md
+++ b/docs/administration.index.md
@@ -56,4 +56,4 @@ per meshcloud installation.
 | &nbsp;&nbsp;[Approve&nbsp;Service&nbsp;Broker](administration.service-brokers.md#approve-service-broker)                  |       &#10003;       |                   |             |            |                    |
 | [Performance&nbsp;Analytics](administration.analytics.md)                                                                 |       &#10003;       |                   |             |            |      &#10003;      |
 
-Please review [meshCustomer roles](meshcloud.customer.md#meshCustomer-roles) for roles available to end-users of your meshStack implementation.
+Please review [meshCustomer roles](meshcloud.customer.md#assign-meshCustomer-roles) for roles available to end-users of your meshStack implementation.

--- a/docs/meshcloud.customer.md
+++ b/docs/meshcloud.customer.md
@@ -24,40 +24,34 @@ Depending on the configuration of your meshStack implementation, you may be able
 
 If you would like to give others access to your meshCustomer and the related meshProjects, go to your "Account" settings.
 You can access them by pressing the settings icon on the top right of the meshPanel.
-From here, navigate to "Access Control". Here you can assign principals (can be a user or a [group](#user-groups)).
+From here, navigate to "Access Control". Here you can invite users or groups to the meshCustomer.
 You can search for users via first & last name, email and username. The users that can be found via
-this search depend on the configured IAM system in you meshInstallation. It is e.g. possible to search for users in an Active Directory or
-a Google Cloud Directory. Additionally all users already known to meshStack can be found via this user search. Besides users, also [groups](#user-groups)
-can be searched for. You can search for groups via their name and identifier.
+this search depend on the configured IAM system in you meshInstallation. It is e.g. possible to search for users in an Active Directory or a Google Cloud Directory. Additionally all users already known to meshStack can be found via this user search. Besides users, also [groups](#user-groups) can be searched for. You can search for groups via their name and identifier.
 
 If you want to invite a user that it is not known to the connected IAM system and meshStack, you are able to invite a user by providing
 the first and last name as well as an email address. The invited user will be matched via the email address when he logs in the first time to meshStack.
 The "invite user" link is available when the search did not return any results.
 
-You can initially setup the role of the principal in the dropdown which describes the access level of the invited principal.
-Press "+" to add the principal to the customer. All users related to the principal will receive an email with the information,
+You can initially setup the meshCustomer role in the dropdown which describes the access level of the invited user or group.
+Press "+" to add to the meshCustomer. All users and members of the group will receive an email with the information,
 that they have been granted access to your meshCustomer.
 
-Assigning principals to a meshCustomer is necessary in order to give a principal access to your [projects](meshcloud.project.md).
-If 4 eyes-principle is active, the principal will not be assigned directly to your meshCustomer. Another Customer Admin has to approve this role
-assignment first. Therefore the principal will appear in the "Pending Requests" section.
+Assigning a meshCustomer role is necessary in order to give access to [meshProjects](meshcloud.project.md) insight the meshCustomer.
+If 4 eyes-principle is active, the user or group will not be assigned directly to your meshCustomer. Another Customer Admin has to approve this role assignment first. Therefore the user or group will appear in the "Pending Requests" section.
 
 ## User Groups
 
-For not having to assign multiple users individually to your projects, you can also group them in a User Group. The User Group is only available inside your
-meshCustomer. User Groups can be assigned roles on a [meshCustomer](#invite-users-to-a-meshcustomer-team) and a [meshProject](meshcloud.project.md#access-anagement-on-a-meshproject) in the same way as for usual users.
-
-In order to reference groups and users in theis documentation and in meshStack, we call the abstraction which covers both types "principal".
+For not having to assign multiple users individually to your projects, you can also group them in a user group. The user group is only available inside your meshCustomer. User groups can be assigned roles on a [meshCustomer](#invite-users-to-a-meshcustomer-team) and a [meshProject](meshcloud.project.md#access-anagement-on-a-meshproject) in the same way as for usual users.
 
 You can view user groups within your customer account by going to the **Groups** section in the **Account** area.
 Currently, creating a group is only supported via [meshObject API](meshstack.api.md).
 
 ## Assign meshCustomer Roles
 
-You can change the role assigned to each principal on the current meshCustomer.
+You can change the role assigned to each user or group on the current meshCustomer.
 To change the assigned role choose a new role from the dropdown and save the changes via the disc icon.
 
-A principal can be assigned multiple roles simultaneously. All users of the principal will receive the combined rights of all their assigned roles.
+A user or a group can be assigned multiple roles simultaneously. All users and members will receive the combined rights of all their assigned roles.
 
 The following roles are available:
 
@@ -106,4 +100,4 @@ meshCustomer roles grant rights in meshStack only. In order to access cloud reso
 
 ## Remove assigned meshCustomer Roles
 
-If you would like to remove a principal from your meshCustomer go to your "Account" settings and select "Customer Access". You can click the "trash" icon in the "Customer Access" section to remove the principal from your meshCustomer. If 4-AP is active in your meshInstallation and the role request has not been approved by another Customer Admin yet, click the "trash" icon in the Pending Role Requests section. When removing the principal on the meshCustomer, the principal is automatically removed from all projects it had access to. All users of the principal also won't be able to access cloud resources of your projects anymore, if they are not assigned via another role binding anymore. The principal users will be informed via email, that their access to the meshCustomer was revoked.
+If you would like to remove a user or group from your meshCustomer go to your "Account" settings and select "Customer Access". You can click the "trash" icon in the "Customer Access" section to remove the user or group from your meshCustomer. If 4-AP is active in your meshInstallation and the role request has not been approved by another Customer Admin yet, click the "trash" icon in the Pending Role Requests section. When removing someone from the meshCustomer, the user or group is automatically removed from all projects it had access to. All users won't be able to access cloud resources of your projects anymore, if they are not assigned via another role binding anymore. The users or members of the group will be informed via email, that their access to the meshCustomer was revoked.

--- a/docs/meshcloud.customer.md
+++ b/docs/meshcloud.customer.md
@@ -14,7 +14,6 @@ the process to some existing ITSM or process automation system. Operators can re
 In any case, the meshCustomer creation process always involves collecting basic customer information like Name, identifier
 and any additional [metadata specific to your organization](meshstack.tag-schema.md#customer-tag-schema).
 
-
 ## Customer Settings
 
 General information of a meshCustomer (like its name) and [Customer Tags](meshstack.tag-schema.md#customer-tag-schema) can be edited here. The customer identifier is also shown here, but it can never be changed, as it is used as an immutable identifier of the meshCustomer for its representation in the different cloud platforms.
@@ -25,27 +24,45 @@ Depending on the configuration of your meshStack implementation, you may be able
 
 If you would like to give others access to your meshCustomer and the related meshProjects, go to your "Account" settings.
 You can access them by pressing the settings icon on the top right of the meshPanel.
-From here, navigate to "Users" and provide the full name as well as the email address of that person.
-You can initially setup the role in the dropdown which describes the access level of the invited user.
-Press "+" to send an invitation email. This step is necessary in order to give a user access to your [projects](meshcloud.project.md).
-After this action the created invitation will appear under the pending customer user role requests section.
+From here, navigate to "Access Control". Here you can assign principals (can be a user or a [group](#user-groups)).
+You can search for users via first & last name, email and username. The users that can be found via
+this search depend on the configured IAM system in you meshInstallation. It is e.g. possible to search for users in an Active Directory or
+a Google Cloud Directory. Additionally all users already known to meshStack can be found via this user search. Besides users, also [groups](#user-groups)
+can be searched for. You can search for groups via their name and identifier.
 
-## View User Groups
+If you want to invite a user that it is not known to the connected IAM system and meshStack, you are able to invite a user by providing
+the first and last name as well as an email address. The invited user will be matched via the email address when he logs in the first time to meshStack.
+The "invite user" link is available when the search did not return any results.
+
+You can initially setup the role of the principal in the dropdown which describes the access level of the invited principal.
+Press "+" to add the principal to the customer. All users related to the principal will receive an email with the information,
+that they have been granted access to your meshCustomer.
+
+Assigning principals to a meshCustomer is necessary in order to give a principal access to your [projects](meshcloud.project.md).
+If 4 eyes-principle is active, the principal will not be assigned directly to your meshCustomer. Another Customer Admin has to approve this role
+assignment first. Therefore the principal will appear in the "Pending Requests" section.
+
+## User Groups
+
+For not having to assign multiple users individually to your projects, you can also group them in a User Group. The User Group is only available inside your
+meshCustomer. User Groups can be assigned roles on a [meshCustomer](#invite-users-to-a-meshcustomer-team) and a [meshProject](meshcloud.project.md#access-anagement-on-a-meshproject) in the same way as for usual users.
+
+In order to reference groups and users in theis documentation and in meshStack, we call the abstraction which covers both types "principal".
 
 You can view user groups within your customer account by going to the **Groups** section in the **Account** area.
 Currently, creating a group is only supported via [meshObject API](meshstack.api.md).
 
 ## Assign meshCustomer Roles
 
-You can change the role assigned to each user on the current meshCustomer.
+You can change the role assigned to each principal on the current meshCustomer.
 To change the assigned role choose a new role from the dropdown and save the changes via the disc icon.
 
-A user can be assigned multiple roles simultaneously. The user will receive the combined rights of all the assigned roles.
+A principal can be assigned multiple roles simultaneously. All users of the principal will receive the combined rights of all their assigned roles.
 
 The following roles are available:
 
-- **Customer Admin**: Has full access to the meshCustomer and its projects and can manage users of the meshCustomer account.
-- **Customer Employee**: Has full access to project resources, but **cannot** manage users, create projects, etc of the meshCustomer account.
+- **Customer Admin**: Has full access to the meshCustomer and its projects and can manage access to the meshCustomer account.
+- **Customer Employee**: Has full access to project resources, but **cannot** manage access, create projects, etc of the meshCustomer account.
 
 ### meshCustomer Roles
 
@@ -63,15 +80,15 @@ The following table provides details about the functionality available to the di
 | &nbsp;&nbsp;[Edit&nbsp;Project](meshcloud.project.md#manage-meshprojects) | &#10003; | |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Project&nbsp;Locations](meshcloud.project.md#add-remove-locations-from-a-meshproject) | &#10003; | |
 | &nbsp;&nbsp;&nbsp;&nbsp;[Payment&nbsp;Information](meshcloud.project.md#provide-payment-information-for-meshproject) | &#10003; | |
-| &nbsp;&nbsp;&nbsp;&nbsp;[Manage&nbsp;Users](meshcloud.project.md#user-management-on-a-meshproject) | &#10003; | |
-| &nbsp;&nbsp;[Expired&nbsp;Access](meshcloud.project.md#expiry-of-a-user-assignment) | &#10003; | |
+| &nbsp;&nbsp;&nbsp;&nbsp;[Access&nbsp;Control](meshcloud.project.md#access-control-on-a-meshproject) | &#10003; | |
+| &nbsp;&nbsp;[Expired&nbsp;Access](meshcloud.project.md#expiration-of-a-principal-assignment) | &#10003; | |
 | &nbsp;&nbsp;[Project&nbsp;Statements](meshcloud.project-metering.md#project-statement) | &#10003; | |
 | &nbsp;&nbsp;[Delete&nbsp;Project](meshcloud.project.md#delete-a-meshproject) | &#10003; | |
 | [Customer&nbsp;Users](meshcloud.customer.md) | &#10003; | |
-| &nbsp;&nbsp;[Invite&nbsp;User](meshcloud.customer.md#invite-users-to-access-a-meshcustomer) | &#10003; | |
-| &nbsp;&nbsp;[Edit&nbsp;User&nbsp;Group](meshcloud.customer.md#manage-groups-of-assigned-users) | &#10003; | |
-| &nbsp;&nbsp;[Remove&nbsp;User](meshcloud.customer.md#remove-users-from-a-meshcustomer) | &#10003; | |
-| [Customer&nbsp;User&nbsp;Groups](meshcloud.customer.md) | &#10003; | |
+| &nbsp;&nbsp;[Give&nbsp;Access](meshcloud.customer.md#invite-users-to-a-meshcustomer-team) | &#10003; | |
+| &nbsp;&nbsp;[Edit&nbsp;Access](meshcloud.customer.md#assign-meshcustomer-roles) | &#10003; | |
+| &nbsp;&nbsp;[Remove&nbsp;Access](meshcloud.customer.md#remove-assigned-meshcustomer-roles) | &#10003; | |
+| [Customer&nbsp;User&nbsp;Groups](meshcloud.customer.md#user-groups) | &#10003; | |
 | [Customer&nbsp;Settings](meshcloud.customer.md#customer-settings) | &#10003; | |
 | [Company&nbsp;Address](meshcloud.project-metering.md#company-billing-addresses) | &#10003; | |
 | [Billing&nbsp;Address](meshcloud.project-metering.md#company-billing-addresses) | &#10003; | |
@@ -85,8 +102,8 @@ The following table provides details about the functionality available to the di
 
 > The roles that are available for Partner and Admin customers are described in the [Administration](administration.index.md) section.
 
-meshCustomer roles grant rights in meshStack only. In order to access cloud resources users need to be [granted a role on a meshProject](meshcloud.project.md#user-management-on-a-meshproject).
+meshCustomer roles grant rights in meshStack only. In order to access cloud resources users need to be [granted a role on a meshProject](meshcloud.project.md#access-control-on-a-meshproject).
 
-## Change or Remove assigned meshCustomer Roles
+## Remove assigned meshCustomer Roles
 
-If you would like to remove a user from your meshCustomer go to your "Account" settings and select "Users". If the user already accepted the invitation, you can click the "trash" icon in the "Users" section to remove the user from your meshCustomer. If a user has already received an invitation before, but never claimed it, click the "trash" icon in the Pending Invitations section. When removing the user on the meshCustomer, the user is automatically removed from all projects he had access to. He also won't be able to access cloud resources of your projects anymore. The user will be informed via email, that his access to the meshCustomer was revoked.
+If you would like to remove a principal from your meshCustomer go to your "Account" settings and select "Customer Access". You can click the "trash" icon in the "Customer Access" section to remove the principal from your meshCustomer. If 4-AP is active in your meshInstallation and the role request has not been approved by another Customer Admin yet, click the "trash" icon in the Pending Role Requests section. When removing the principal on the meshCustomer, the principal is automatically removed from all projects it had access to. All users of the principal also won't be able to access cloud resources of your projects anymore, if they are not assigned via another role binding anymore. The principal users will be informed via email, that their access to the meshCustomer was revoked.

--- a/docs/meshcloud.index.md
+++ b/docs/meshcloud.index.md
@@ -19,8 +19,9 @@ The figure and table below explain the relation of the most important concepts i
 | [meshUser](./meshcloud.profile.md)             | An individual user account. Roles define its level of access and permissions.             |
 | [meshPartner](administration.index.md)         | Partners administrate and support a meshcloud installation.                               |
 | [meshCustomer](./meshcloud.customer.md)        | A DevOps Team that manages its own [meshProject](./meshcloud.project.md)s and permissions |
+| [meshCustomerUserGroup](./meshcloud.customer.md)| A group of users on a meshCustomer, that can be granted access via roles. |
 | [meshProject](./meshcloud.project.md)          | A multi-cloud project owned by a [meshCustomer](./meshcloud.customer.md)                  |
-| [meshTenant](./meshcloud.tenant.md)                                     | An isolated environment in a specific cloud platform, e.g. an AWS Account.                |
+| [meshTenant](./meshcloud.tenant.md)            | An isolated environment in a specific cloud platform, e.g. an AWS Account.                |
 | [meshLandingZone](meshcloud.landing-zones.md)  | Defines configuration and governance policies for cloud environments.                     |
 | [meshPlatform](meshcloud.platform-location.md) | An individual cloud platform connected to meshcloud.                                      |
 | [meshLocation](meshcloud.platform-location.md) | A grouping of meshPlatforms, e.g. by geographic region.                                   |

--- a/docs/meshcloud.project.md
+++ b/docs/meshcloud.project.md
@@ -71,7 +71,7 @@ Via "Projects" -> "Expired Access", the expired or soon to expire role assignmen
 
 ### Unassign user or group from a meshProject
 
-In the **Project Access** section you can click the `-` button in the row of a user or group to remove them from the project. The users and memebers will not be able to access this project in meshPortal and the cloud platforms anymore. You can add the  to your project again later on and all related users will get access again.
+In the **Project Access** section you can click the `-` button in the row of a user or group to remove them from the project. The users and memebers will not be able to access this project in meshPortal and the cloud platforms anymore. You can add the user or group to your project again later on and all related users will get access again.
 
 ## Delete a meshProject
 

--- a/docs/meshstack.authorization.md
+++ b/docs/meshstack.authorization.md
@@ -15,15 +15,15 @@ meshStack includes **meshObject roles** that manage permissions on different [me
 
 ### Role Bindings
 
-**Role bindings** assign a meshUser a meshObject role on specific meshObject. Role bindings are also exposed via the [meshObject API](meshstack.api.md#meshobject-api). For example, a `meshProjectUserBinding` associates a meshUser with a meshProject and a meshProject Role.
+**Role bindings** assign a meshUser or meshCustomerUserGroup a meshObject role on specific meshObject. Role bindings are also exposed via the [meshObject API](meshstack.api.md#meshobject-api). For example, a `meshProjectUserBinding` associates a meshUser with a meshProject and a meshProject Role.
 
 Role bindings can also have a managed expiry date after which meshStack will automatically revoke the role.
 
-Some roles also include permissions that allow users to manage role bindings in self-service. For example, a user with the "Customer Admin" [meshCustomer Role](meshcloud.customer.md#meshCustomer-roles) can add new role bindings to that meshCustomer.
+Some roles also include permissions that allow users to manage role bindings in self-service. For example, a user with the "Customer Admin" [meshCustomer Role](meshcloud.customer.md#assign-meshCustomer-roles) can add new role bindings to that meshCustomer.
 
-### Role Requests
+### Access Requests
 
-Any change in role binding always occurs via a **role request**. Role requests can be either approved or denied. Role requests may be subject to **approval conditions**. Operators can configure these conditions to meet a range of organisational and regulatory requirements like e.g. a 4 eyes principle.
+Any change in role binding always occurs via an **access request**. Access requests can be either approved or denied. Access requests may be subject to **approval conditions**. Operators can configure these conditions to meet a range of organisational and regulatory requirements like e.g. a 4 eyes principle.
 
 Role requests produce an audit trail and may trigger notifications to involved parties.
 
@@ -31,7 +31,7 @@ Role requests produce an audit trail and may trigger notifications to involved p
 
 ### meshCustomer Roles
 
-[meshCustomer Roles](meshcloud.customer.md#meshCustomer-roles) control the permission on a [meshCustomer](meshcloud.customer.md) and the [meshObjects](meshcloud.index.md) owned by that meshCustomer. Users must have a corresponding role binding in order to access meshObjects owned by a meshCustomer like [meshProjects](meshcloud.project.md).
+[meshCustomer Roles](meshcloud.customer.md#assign-meshCustomer-roles) control the permission on a [meshCustomer](meshcloud.customer.md) and the [meshObjects](meshcloud.index.md) owned by that meshCustomer. Users must have a corresponding role binding in order to access meshObjects owned by a meshCustomer like [meshProjects](meshcloud.project.md).
 
 Users with the right permissions can [assign meshCustomer roles](meshcloud.customer.md#assign-meshcustomer-roles) in self-service.
 
@@ -43,9 +43,9 @@ Users with the right permissions can assign meshCustomer roles in self-service w
 
 ### meshProject Roles
 
-[meshProject roles](meshcloud.project.md#project-roles) grant users access to meshProjects and their associated [meshTenants](meshcloud.tenant.md). meshProject roles are special in that they do not grant permissions within meshStack (apart from permission to view the meshProject). Instead meshStack replicates meshProject roles bindings to the associated meshTenants according to their [meshPlatform](meshcloud.platform-location.md) and [Landing Zone](meshcloud.landing-zones.md) configuration.
+[meshProject roles](meshcloud.project.md#project-roles) grant users access to meshProjects and their associated [meshTenants](meshcloud.tenant.md). meshProject roles are special in that they do not grant permissions within meshStack (apart from permission to view the meshProject). Instead meshStack replicates meshProject role bindings to the associated meshTenants according to their [meshPlatform](meshcloud.platform-location.md) and [Landing Zone](meshcloud.landing-zones.md) configuration.
 
-Users with the right permissions can [assign meshProject roles](meshcloud.project.md#assign-user-to-a-meshproject) in self-service. Users can only have meshProject role bindings as long as they also have a role binding on the meshCustomer that is the owner of that meshProject. Revocation of this meshCustomer role binding causes revocation of all associated meshProject role bindings.
+Users with the right permissions can [assign meshProject roles](meshcloud.project.md#assign-user-to-a-meshproject) in self-service. Users and groups can only have meshProject role bindings as long as they also have a role binding on the meshCustomer that is the owner of that meshProject. Revocation of this meshCustomer role binding causes revocation of all associated meshProject role bindings.
 
 ## Configuration Options
 
@@ -94,7 +94,7 @@ let example =
 
 ### Role Request Approval
 
-In case you are required to implement a 4-eye-principle for user role requests for compliance purposes you can configure the meshStack to do so. The approval can be configured in the [meshStack configuration model](meshstack.configuration.md) under `meshfed.web.user.rolerequest` as follows:
+In case you are required to implement a 4-eye-principle for access requests for compliance purposes you can configure the meshStack to do so. The approval can be configured in the [meshStack configuration model](meshstack.configuration.md) under `meshfed.web.user.rolerequest` as follows:
 
 ```haskell
 { minApprovalCount = Some 2
@@ -102,16 +102,16 @@ In case you are required to implement a 4-eye-principle for user role requests f
 }
 ```
 
-If the `minApprovalCount` option is set to 2 or higher upon project user invitation a popup will ask the inviting user to enter some additional information like why this role is required and for how long. These information will be visible to customer administrators who then can accept or decline such a request.
+If the `minApprovalCount` option is set to 2 or higher upon adding a project role binding, a popup will ask the inviting user to enter some additional information like why this role is required and for how long. This information will be visible to customer administrators who then can accept or decline such a request.
 
 <figure>
   <img src="assets/authorization.additional-role-info.png" style="width: 50%;" alt="Additional Information Role Request Popup">
   <figcaption>Popup requesting additional information for a project role request</figcaption>
 </figure>
 
-New project role requests must be approved before the binding is created. The customer admin making the role request registers an implict approval of the request. Each customer admin can only reqister a single approval for a role request. This ensures that a _different_ customer admin must register the 2nd approval before the binding is created.
+New project role requests must be approved before the binding is created. The customer admin making the role request registers an implict approval of the request. Each customer admin can only reqister a single approval for an access request. This ensures that a _different_ customer admin must register the 2nd approval before the binding is created.
 
-Customer admins will be notified by email about pending approvals. The affected user is also informed via mail about approved or rejected role requests.
+Customer admins will be notified by email about pending approvals. The affected user is also informed via mail about approved or rejected role requests. In case of a customer user group, all users of the group are informed.
 
 When any customer admin declines the role request, the role request is immediately cancelled.
 
@@ -154,7 +154,6 @@ The following claims in the OIDC token represent this information and can be use
 
 The `MC_PROJECTS` claim contains all projects the user has access to in the scoped meshCustomer. The `MC_GROUPS` also contain only the meshCustomer roles the user is assigned to in the current customer. This claim is currently defined as an array for future flexibility. Currently a user can only have one role assigned per meshCustomer.
 
-
 #### Authorization via replication
 
 For platforms that don't support the [Authorization via OIDC](#authorization-via-oidc), access rights are replicated during project replication. Cloud platforms provide their own ACL system and meshStack configures it as defined in the meshProject. E.g. this could be an assignment of certain roles for a certain project in the cloud platform.
@@ -167,6 +166,6 @@ A Service User can be created and deleted by all users assigned to the project. 
 
 ## Role Revocation
 
-User role revocation on [meshProject](meshcloud.project.md#unassign-user-from-a-meshproject) and [meshCustomer](meshcloud.customer.md#remove-users-from-a-meshcustomer) level allow Customer Admins to always limit access to the meshCustomer and meshProjects to the users that actually need access. Users who no longer should have access can easily be revoked access. Administrators also have the possibility to revoke roles for a user to all meshCustomers and meshProjects and deactivate this user completely in the complete meshStack via the [delete user](administration.users.md#delete-user) functionality.
+User role revocation on [meshProject](meshcloud.project.md#unassign-principal-from-a-meshproject) and [meshCustomer](meshcloud.customer.md#remove-assigned-meshcustomer-roles) level allow Customer Admins to always limit access to the meshCustomer and meshProjects to the users that actually need access. Users who no longer should have access can easily be revoked access. Administrators also have the possibility to revoke roles for a user to all meshCustomers and meshProjects and deactivate this user completely in the complete meshStack via the [delete user](administration.users.md#delete-user) functionality.
 
 Users who e.g. left the company, can automatically be revoked in meshStack as described [here](meshstack.user-revocation.md).

--- a/docs/meshstack.platform-location.md
+++ b/docs/meshstack.platform-location.md
@@ -19,7 +19,7 @@ This feature can be used for example to restrict access to a public cloud provid
 ### Project-level
 
 Customers can create [meshProjects](meshcloud.project.md) that use the Locations available to their Customer account.
-Configuring the locations available to a project is typically restricted to users with the [Customer Admin Role](meshcloud.customer.md#meshCustomer-roles), providing a further level of possible delegation.
+Configuring the locations available to a project is typically restricted to users with the [Customer Admin Role](meshcloud.customer.md#assign-meshCustomer-roles), providing a further level of possible delegation.
 
 ## Deprovisioning / Deleting Projects
 


### PR DESCRIPTION
With the introduction of the principal abstraction for users and groups, documentation around access control needed to be adapted.

I also used the term "principal" in the documentation so we can apply a ubiquitous language. We decided not to use it in the UI, but i think it still makes sense in the documentation, as we have more options of describing what a principal is.