### PR TITLE
feat(azure): improve azure operator documentation

### DIFF
--- a/docs/meshstack.azure.index.md
+++ b/docs/meshstack.azure.index.md
@@ -209,7 +209,7 @@ Furthermore in order to prevent the replicator from assigning itself more permis
 
 #### EA Account Permissions
 
-Wehn using an [Enterprise Enrollment Account (EA) for Subscription provisioning](#enterprise-enrollment-account), an EA Administrator must authorize the [meshcloud Service Principal](#service-principal-setup) on the Enrollment Account [following the official instructions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/grant-access-to-create-subscription).
+When using an [Enterprise Enrollment Account (EA) for Subscription provisioning](#enterprise-enrollment-account), an EA Administrator must authorize the [meshcloud Service Principal](#service-principal-setup) on the Enrollment Account [following the official instructions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/grant-access-to-create-subscription).
 
 When using powershell, use the following command and substitue parameters as follows:
 

--- a/docs/meshstack.azure.index.md
+++ b/docs/meshstack.azure.index.md
@@ -193,7 +193,7 @@ Furthermore in order to prevent the replicator from assigning itself more permis
                   },
                   {
                     "field": "Microsoft.Authorization/roleAssignments/principalId",
-                    "equals": "<AZURE_SERVICE_PRINCIPAL_ID>"
+                    "equals": "<SERVICE_PRINCIPAL_OBJECT_ID>"
                   },
                 ]
               }

--- a/docs/meshstack.azure.index.md
+++ b/docs/meshstack.azure.index.md
@@ -164,7 +164,7 @@ All permissions left are therefore granted only via the management group hierarc
 
 You must must grant the meshcloud Service Principal this level access to all [management groups](https://docs.microsoft.com/en-us/azure/governance/management-groups/) used in [Landing Zones](./meshstack.azure.landing-zones.md).
 
-In Azure Portal, navigate to the "Management Groups" blade, then click on the "Details" link of the management group you want to give access to. Select "Access Control (IAM)" from the menu and create a Role assignment of the custom IAM role created above for the [replicator Service Principal](#replicator).
+In Azure Portal, navigate to the "Management Groups" blade, then click on the "Details" link of the management group you want to give access to. Select "Access Control (IAM)" from the menu and create a role assignment of the custom IAM role created above for the [replicator Service Principal](#replicator).
 
 > Access to the Management Groups may require the "Global Administrator" role with [elevated access](https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin). In case you're not able to see all management groups after elevating access, try signing out and back in to Azure Portal.
 

--- a/docs/meshstack.azure.metering.md
+++ b/docs/meshstack.azure.metering.md
@@ -3,11 +3,5 @@ id: meshstack.azure.metering
 title: Metering
 ---
 
-meshStack imports metering data from Azure via the Azure Cost Management API. It collects data for the previous and the current month.
+meshStack imports metering data from Azure via the [Azure Cost Management API](https://docs.microsoft.com/en-us/rest/api/cost-management/). It collects data for the previous and the current month.
 Azure only provides data for the previous day, so Azure Usage Reports shown in meshStack will not provide data for the current day.
-
-## Permission Model
-
-In order to read resource usages, a metering principal is needed (creation of new service principals are defined [here](./meshstack.azure.index.md#replicator)). It requires the following permissions/roles on all resources which should be accessed by the meshstack's metering service:
-
-- `Cost Management Reader`


### PR DESCRIPTION
- fix recommended privilege escalation policy (use deny effect, prevent
  all role assignments)
- remove "meshStack provisioned identities" section as we recommend
  customers always use externally provisioned identities with Azure
- structure configuration setup as a guide that includes replicator
  & kraken SPNs
- renamed "meshcloud AAD tenant" to "workload AAD Tenant" as this more
  closely captures what the AAD tenant is meant for
- clarify instructions for setting up the EA role assignment to our SPNs
  (Azure powershell module is broken and doesn't support -ObjectId parameter
  for SPNs, claiming role assignments to SPNs was unsupported when it isn't)