### PR TITLE
refactor(meshmarketplace): unify "custom" and "profile" pages

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -95,8 +95,7 @@
       "meshstack.meshmarketplace.metering",
       "meshstack.meshmarketplace.broker-tutorial",
       "meshstack.meshmarketplace.dashboard-tutorial",
-      "meshstack.meshmarketplace.profile",
-      "meshstack.meshmarketplace.custom"
+      "meshstack.meshmarketplace.profile"
     ]
   }
 }


### PR DESCRIPTION
- reduce duplication between metering page and profile/catalog
  description
- split tenant services as a separate top-level concept page
  to improve readability (profile as an overview, separate
  pages to elaborate on details)