### PR TITLE
Restructures GCP/AAD IDP config docs

### DIFF
--- a/docs/meshstack.azure.index.md
+++ b/docs/meshstack.azure.index.md
@@ -227,16 +227,6 @@ In order to read resource usages, a metering principal is needed. It requires th
 
 - `Cost Management Reader`
 
-
-### Identity Provider (IdP) Lookup
-
-This principal is only required if the AAD is actually be used as source of user information when assigning users to meshCustomers or meshProjects inside the meshPanel. In order to use this functionality, create a new principal (described in **Replicator** &rarr; **AAD Level Permissions** step 1 and 2) and assign the following required permissions:
-
-- `User.Read.All`
-
-> Since `User.Read.All` is a Role permission, you will also need to grant admin consent in AAD on the assignment
-
-
 ## Blueprint Configuration
 
 The `Azure Blueprints` service principal id is different in every AAD Tenant, so we need to find the id

--- a/docs/meshstack.customer-group-sync.md
+++ b/docs/meshstack.customer-group-sync.md
@@ -106,16 +106,19 @@ transformations on the matched attribute, called the `RegexField`. The `RegexFie
 ```dhall
 let BaseField =
     {-
-        transformationType:
-           One of static or regex. Static transformation will simply take the LDAP attribute value.
-           The regex transformation will perform extra operations on the matched value.
-        field:
-           The meshObject field that should be assigned the result of this field mapping.
-           For example, "metadata.name"
-        attribute:
-           The LDAP attribute that should be processed. For example "cn"
-        postProcessor:
-           Any post processing function that should be run on the mapped value. Can be one of UPPERCASE or LOWERCASE
+      transformationType:
+          One of "static" or "regex". Static transformation will simply take the LDAP attribute value.
+          The regex transformation will perform extra operations on the matched value.
+
+      field:
+          The meshObject field that should be assigned the result of this field mapping.
+          For example, "metadata.name"
+
+      attribute:
+          The LDAP attribute that should be processed. For example "cn"
+
+      postProcessor:
+          Any post processing function that should be run on the mapped value. Can be one of UPPERCASE or LOWERCASE
     -}
       { transformationType : Text
       , field : Text
@@ -133,13 +136,16 @@ let BaseField =
 ```dhall
 let RegexField =
     {-
-        rules:
-            A list of regex rules that the LDAP attributes will be tested against for a match. The matching is performed
-            sequentially until a match is found.
-        template:
-            An optional template where the extracted value should be inserted into. The format should follow the Java String.format
-            contract.
-        otherwise: A optional default value to be assigned if none of the rules match.
+      rules:
+          A list of regex rules that the LDAP attributes will be tested against for a match.
+          The matching is performed sequentially until a match is found.
+
+      template:
+          An optional template where the extracted value should be inserted into.
+          The format should follow the Java String.format contract.
+
+      otherwise:
+          An optional default value to be assigned if none of the rules match.
     -}
         BaseField
       ⩓ { rules : List RegexRule
@@ -159,13 +165,14 @@ The RegexRule mentioned above is as follows.
 ```dhall
 let RegexRule =
     {-
-        value:
-            This is an optional parameter. If it is defined, if the LDAP attribute matches the
-            regular expression, this value will be assigned as the value of the meshObject field.
-        regex:
-            The regular expression against which the LDAP attribute should be matched. If the value parameter
-            is not defined, the regular expression MUST contain a group and the first group will be assigned
-            as the value of the meshObject field.
+      value:
+          This is an optional parameter. If it is defined, if the LDAP attribute matches the
+          regular expression, this value will be assigned as the value of the meshObject field.
+
+      regex:
+          The regular expression against which the LDAP attribute should be matched. If the value parameter
+          is not defined, the regular expression MUST contain a group and the first group will be assigned
+          as the value of the meshObject field.
     -}
       { regex : Text, value : Optional Text }
 ```

--- a/docs/meshstack.gcp.index.md
+++ b/docs/meshstack.gcp.index.md
@@ -210,8 +210,8 @@ let GcpPlatformCoreConfiguration =
       allowHierarchicalFolderAssignment:
         Configuration flag to enable or disable hierarchical folder assignment in GCP. This means
         projects can be assigned to sub folders of the defined resource manager folder in a landing zone.
-        If this flag is disabled the replicator forces tenants directly under the resource manager folder.
-        Every tenant which is not directly attached to the resource manager folder will be moved there via gcp function.
+        If this config flag is disabled the replicator forces to create projects only directly under the resource manager folder.
+        Every project which is not directly attached to the resource manager folder will be then moved via gcp function to the right folder.
     -}
       { platform : Text
       , domain : Text


### PR DESCRIPTION
Removes duplicate documentation and unifies it.
Added proper Dhall snippets from meshfed.

For now the GCP docs are not adapted as there is an open ticket which will very likly remove the impersonated user and alter config model so I dont need to document it. This must be adapted in this upcoming ticket.