### PR TITLE
feat: JSON schema for payment methods

### DIFF
--- a/docs/meshcloud.payment-methods.md
+++ b/docs/meshcloud.payment-methods.md
@@ -38,7 +38,7 @@ One way of creating payment methods is via the meshPanel. To do so, make sure th
 5. Choose a type for the payment method. Read more [here](#types-of-payment-methods) on what type to choose and what the individual differences are.
 6. (This is optional) Set a maximum amount of EUR on the payment method to indicate the remaining budget of this payment method.
 7. (This is optional) Set an expiration date for the payment method. This is especially useful when a budget expires, e.g. at the end of the accounting year.
-8. Additionally, you can enter custom settings to inject metadata into the payment method. This is useful when you want to enhance the payment method with organizational details like the cost center number or the business unit.
+8. Additionally, you can enter tags for the payment method, which are custom per meshImplementation (also see [Tag Schema](meshstack.tag-schema.md)). This is useful when you want to enhance the payment method with organizational details like the cost center number or the business unit.
 9. Click 'Save' and your new payment method will be available to the meshCustomer it was created in!
 
 ### Creating a Payment Method via the meshObject API
@@ -75,9 +75,9 @@ After setting a payment method, you can continue the project creation flow and s
 
 ## The Payment Method Lifecycle: Enhance with Metadata
 
-As it is difficult to handle large amounts of payment methods only via their names or identifiers, there is the possibility to provide metadata (in the form of key-value pairs) to the payment methods. This metadata can be provided when creating/editing the payment method in the meshPanel. This is already described in step 8 [here](#creating-a-payment-method-via-the-meshpanel).
+As it is difficult to handle large amounts of payment methods only via their names or identifiers, there is the possibility to provide tags (also see [Tag Schema](meshstack.tag-schema.md)) to the payment methods. This metadata can be provided when creating/editing the payment method in the meshPanel. This is already described in step 8 [here](#creating-a-payment-method-via-the-meshpanel).
 
-An alternative way of providing metadata to payment methods is via the meshObject API. The API docs will describe how to inject the metadata in payment methods.
+An alternative way of providing metadata to payment methods is via the meshObject API. The API docs will describe how to inject tags in payment methods.
 
 ## The Payment Method Lifecycle: Exporting Data for External Systems
 

--- a/docs/meshstack.tag-schema.md
+++ b/docs/meshstack.tag-schema.md
@@ -30,9 +30,9 @@ Operators can model this metadata as **tags** using a [tag schema](#tag-schemas)
 [Configured tag-schemas](meshstack.tag-schema.md) describe the tags available on each meshModel entity and
 their associated validation rules. These rules can describe for example if a tag is required or optional.
 
-> meshStack currently supports tag schemas on [meshCustomers](meshcloud.customer.md), [meshProjects](meshcloud.project.md) and [meshLandingZones](meshcloud.landing-zones.md).
+> meshStack currently supports tag schemas on [meshCustomers](meshcloud.customer.md), [meshProjects](meshcloud.project.md), [meshLandingZones](meshcloud.landing-zones.md) and [meshPaymentMethods](meshcloud.payment-methods.md).
 
-For each supported entity, meshStack can maintain two separate tag-schemas: **unrestricted** and **restricted** tags.
+For meshCustomer and meshProject tags, meshStack can maintain two separate tag-schemas: **unrestricted** and **restricted** tags. For meshLandingZones and meshPaymentMethods only **restricted** tags are supported.
 
 ### Unrestricted Tags
 
@@ -164,24 +164,22 @@ Operators can configure tag schemas in the [meshStack configuration model](meshs
 
 ```dhall
 {
-  customerTagSchema = Some "./my-customer-tag-schema.json"
-, projectTagSchema = Some "./my-project-tag-schema.json"
-, landingZoneTagSchema = Some "./my-landing-zone-tag-schema.json"
+  customer-tag-schema = Some "./my-customer-tag-schema.json"
+, project-tag-schema = Some "./my-project-tag-schema.json"
+, landing-zone-tag-schema = Some "./my-landing-zone-tag-schema.json"
+, payment-method-tag-schema = Some "./payment-method-tag-schema.json"
 }
 ```
 
 The schemas need to be available in the configuration repository.
 
-### Payment Methods
+### Tags on Payment Methods
 
-[Payment Methods](meshcloud.payment-methods.md) can also provide metadata information. For example,
+[Payment Methods](meshcloud.payment-methods.md) can also provide tag information. For example,
 the default "cost center" payment method provides the `costCenter` tag.
 
-Operators can also add additional metadata information to [Payment Methods](meshcloud.payment-methods.md).
+Operators can also add additional tags to [Payment Methods](meshcloud.payment-methods.md).
 This is useful if your organization needs additional metadata like e.g. contract or budget numbers to chargeback cloud costs.
-
-> It's currently not possible to validate payment method metadata using a tag schema. This feature is only available to Payment Methods created via the [meshStack API](./meshstack.api.md).
-
 
 ## Tags in Landing Zones
 


### PR DESCRIPTION
Extend doc to describe that JSON schemas can now be defined for payment method tags