### PR TITLE
feat: Adds information about the Kubernetes configuration

### DIFF
--- a/docs/meshstack.azure.index.md
+++ b/docs/meshstack.azure.index.md
@@ -1,6 +1,6 @@
 ---
 id: meshstack.azure.index
-title: Integration Guide
+title: Integration
 ---
 
 meshcloud can automatically provision Azure Subscriptions as Tenants for [meshProjects](./meshcloud.project.md) and configure them according to your organiziations policies

--- a/docs/meshstack.customer-group-sync.md
+++ b/docs/meshstack.customer-group-sync.md
@@ -444,7 +444,10 @@ let example
         { username = "identityconnectorapi"
         , password =
             Secret.Native "EXTERNAL_IDENTITYCONNECTOR_MESH_API_PASSWORD"
-        , authorities = [ Authority.EXTERNAL_MESH_OBJECT_IMPORT ]
+        , authorities =
+          [ Authority.EXTERNAL_MESH_OBJECT_IMPORT
+          , Authority.CUSTOMEROWNER_ASSIGN
+          ]
         }
       }
 ```

--- a/docs/meshstack.gcp.index.md
+++ b/docs/meshstack.gcp.index.md
@@ -185,6 +185,7 @@ let GcpPlatformCoreConfiguration =
           1. meshCustomer identifier
           2. meshProject identifier
           3. meshProject ID (numeric)
+          4. role name suffix (configurable via Landing Zone)
 
       allowHierarchicalFolderAssignment:
         Configuration flag to enable or disable hierarchical folder assignment in GCP. This means
@@ -221,8 +222,8 @@ let example
       , allow-hierarchical-folder-assignment = True
       , tenant-tags =
         { namespace-prefix = "meshstack_"
-        , tag-definitions =
-          [ { name = "cident"
+        , tag-mappers =
+          [ { key = "cident"
             , value-pattern = "prefix-\${customerIdentifier}"
             }
           ]

--- a/docs/meshstack.kubernetes.config.md
+++ b/docs/meshstack.kubernetes.config.md
@@ -1,0 +1,120 @@
+---
+id: meshstack.kubernetes.config
+title: Configuration Reference
+---
+
+This section describes the configuration of a Kubernetes Platform Instance in the meshStack configuration model at `mesh.platforms`.
+
+For easier reference the following sections break down the configuration model in multiple parts. The union of these defines the full configuration model.
+
+## Core Configuration
+
+The core configuration is the basic setup for Kubernetes. I
+
+<!--snippet:mesh.platforms.kubernetes.core#type-->
+
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Dhall Type-->
+```dhall
+let KubernetesPlatformCoreConfiguration =
+    {-
+      platform:
+        The meshPlatform identifier
+
+      access-token:
+        Access token of the Kubernetes Service Principal. For more information on how to create this
+        principal with the correct access rights, please check the meshcloud Kubernetes documentation.
+
+      base-url:
+        The Base URL of the Kubernetes Cluster API.
+
+      disable-ssl-validation:
+        Disables SSL validation of the client. Advisable only for testing.
+
+      aks:
+        Add this part of the config if this is an AKS cluster.
+    -}
+      { platform : Text
+      , access-token : Secret
+      , base-url : Text
+      , disable-ssl-validation : Bool
+      , aks : Optional Aks
+      }
+```
+<!--Example-->
+```dhall
+let example
+    : KubernetesPlatformCoreConfiguration
+    = { platform = "kubernetes.mylocation"
+      , access-token = Secret.Native "ey*********"
+      , base-url =
+          "https://aks-meshcloud-ABCDEFGH.aaa.westeurope.azmk8s.io:443"
+      , disable-ssl-validation = False
+      , aks = None Aks
+      }
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## AKS Configuration
+
+If this is an AKS cluster, please provide this part of the configuration as well.
+
+<!--snippet:mesh.platforms.kubernetes.aks#type-->
+
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Dhall Type-->
+```dhall
+let Aks =
+    {-
+      groupNamePattern:
+        Users need a cluster access permission in Azure in order to get credentials. This property defines
+        how the name of this AAD group is chosen.
+        It consists of a Java String.format() format string, receiving the following arguments:
+
+          1. meshCustomer identifier
+          2. meshProject identifier
+          3. meshProject ID (numeric)
+          4. role name suffix (configurable via Landing Zone)
+          5. platform identifier
+          6. location identifier.
+
+      aksSubscriptionId:
+        Azure Subscription ID that contains the AKS Cluster.
+
+      redirectUrl:
+        If users are invited (to get permissioned on the AKS cluster) into the AAD this is the invitation
+        redirect link they see in their invitation mail (same as in the Azure platform configuration).
+
+      sendAzureInvitationMail:
+        Flag if invitation mails are send at all.
+
+      servicePrincipal:
+        Service principal of the replicator that is used to setup the Azure user permissions for the AKS cluster
+        access.
+    -}
+      { groupNamePattern : Text
+      , aksSubscriptionId : Text
+      , redirectUrl : Text
+      , sendAzureInvitationMail : Bool
+      , servicePrincipal : ServicePrincipal
+      }
+```
+<!--Example-->
+```dhall
+let example
+    : Aks
+    = { groupNamePattern = "aks-%s.%s-%4\$s"
+      , aksSubscriptionId = "1234-1234-1234-1234"
+      , redirectUrl = "https://example.com"
+      , sendAzureInvitationMail = False
+      , servicePrincipal =
+        { aad-tenant = "example.onmicrosoft.com"
+        , object-id = "655985db-ca43-4b9f-b317-9dd3d0289c50"
+        , client-id = "2a51f406-27fd-4e40-8bd3-fe83ff934a47"
+        , client-secret = Secret.Native "AZURE_CLIENT_SECRET"
+        }
+      }
+```
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/meshstack.kubernetes.index.md
+++ b/docs/meshstack.kubernetes.index.md
@@ -3,16 +3,22 @@ id: meshstack.kubernetes.index
 title: Integration
 ---
 
+
 meshStack supports project creation, configuration, user management and SSO for Kubernetes clusters.
 Our Kubernetes integration is distribution-independent and is purely based on "vanilla" upstream Kubernetes services.
 Operators should be able to successfully integrate any Kubernetes distribution of their chosing as long as it has the
 required APIs and configuration options available.
 
+The following Kubernetes distributions are supported:
+
+- **Native Kubernetes** Supports user authentication via Keycloak integration.
+- **Azure Kubernetes Services** Supports Azure AAD authenticated users to get seamless access to the AKS cluster.
+
 ## Integration Overview
 
 To enable integration with Kubernetes, operators deploy and configure the meshStack Kubernetes Module. Operators can configure one or multiple `PlatformInstance`s of `PlatformType` Kubernetes. This makes Kubernetes available to meshProjects like any other cloud platform in meshStack.
 
-meshStack automatically configures Kubernetes namespaces and RBAC permissions to integrate SSO with [meshStack Identity Federation](./meshstack.identity-federation.md).
+Depending on which Kubernetes distribution you want to use you will need to follow different steps. Below are the steps for the [meshStack Identity Federation](./meshstack.identity-federation.md) integration as well as for the [Azure Kubernetes Services](#azure-kubernetes-services).
 
 ## Prerequisites
 
@@ -34,30 +40,15 @@ Your meshStack installation needs to be configured to restrict meshProject and m
 
 You can refer to the [official Documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names).
 
-### API Server Configuration
-
-In order to integrate with [meshStack Identity Federation](./meshstack.identity-federation.md), operators need to configure the meshStack Identity Broker as a trusted authentication provider. You will need to configure your Kubernetes distribution to apply the following configuration to [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/). Variables prefixed with `$` must
-be replaced with the appropriate values for your individual meshStack installation.
-
-```yaml
-authorization-mode: RBAC
-oidc-issuer-url: "https://$SSO_URL/auth/realms/meshfed"
-oidc-client-id: "meshfed-oidc"
-oidc-username-claim: "sub"
-oidc-username-prefix: "mesh:"
-oidc-groups-claim: "MC_CUSTOMER_PROJECTS"
-oidc-groups-prefix: ""
-cors-allowed-origins: "http://localhost:9001,https://.*"
-```
 
 ### meshStack Service Accounts
 
 The meshStack Kubernetes Modules use dedicated Kubernetes ServiceAccounts to work with Kubernetes APIs on behalf of meshStack.
 To create these credentials, create the following objects via `kubectl apply` as a Cluster Administrator.
 
-Service principals are located in configured namespaces. In the following yaml files we use the "meshcloud" namespace for the principals.
+Service principals are located in configured namespaces. In the following YAML files we use the "meshcloud" namespace for the principals.
 You can also define a different namespace if you prefer.
-Before applying the yaml file, the namespace has to be created first via `kubectl create namespace meshcloud`.
+Before applying the YAML file, the namespace has to be created first via `kubectl create namespace meshcloud`.
 
 #### Tenant Management
 
@@ -92,6 +83,35 @@ rules:
   - delete
   - update
 - apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - appliedclusterresourcequotas
+  - clusterresourcequotas
+  - clusterresourcequotas/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
   - rbac.authorization.k8s.io
   resources:
   - roles
@@ -103,6 +123,7 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
@@ -111,12 +132,14 @@ rules:
   - delete
   - update
 - apiGroups:
+  - ""
   - rbac.authorization.k8s.io
   resources:
   - clusterroles
   verbs:
   - bind
   resourceNames:
+  # ATTENTION: Replace these roles with the actual ClusterRoles you want to map for meshProject roles
   - admin
   - edit
   - view
@@ -181,7 +204,7 @@ roleRef:
   name: meshfed-metering
 ```
 
-#### Get service account token
+### Service Account Token
 
 Next, retrieve the access token for the service accounts:
 
@@ -195,7 +218,9 @@ Operators need to securely inject these access token into the configuration of t
 
 ### Custom meshProject Roles
 
-If you want to use custom roles to be mapped to your meshProject roles (and not just the pre-defined `admin`, `edit` and `view` roles) you need to make sure to also list these roles in the clusterrole binding section for the meshfed-service principle. It is not allowed for the service-principle to bind roles granting more rights then itself has, so the right to bind these roles must be explicitly given.
+> If you want to use custom roles to be mapped to your meshProject roles (and not just the pre-defined `admin`, `edit` and `view` roles) you need to make sure to also list these roles in the Cluster Role binding section for the meshfed-service principal.
+
+It is not allowed for the service-principal to bind roles granting more rights then itself has, so the right to bind these roles must be explicitly given.
 
 For example if you plan to use a role named `my-custom-role` please change the relevant section in the tenant management document to:
 
@@ -213,4 +238,34 @@ For example if you plan to use a role named `my-custom-role` please change the r
   - edit
   - view
   - my-custom-role
+```
+
+## meshStack Identity Federation
+
+In order to integrate with [meshStack Identity Federation](./meshstack.identity-federation.md), operators need to configure the meshStack Identity Broker as a trusted authentication provider. You will need to configure your Kubernetes distribution to apply the following configuration to [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/). Variables prefixed with `$` must
+be replaced with the appropriate values for your individual meshStack installation.
+
+```yaml
+authorization-mode: RBAC
+oidc-issuer-url: "https://$SSO_URL/auth/realms/meshfed"
+oidc-client-id: "meshfed-oidc"
+oidc-username-claim: "sub"
+oidc-username-prefix: "mesh:"
+oidc-groups-claim: "MC_CUSTOMER_PROJECTS"
+oidc-groups-prefix: ""
+cors-allowed-origins: "http://localhost:9001,https://.*"
+```
+
+meshStack automatically configures Kubernetes namespaces and RBAC permissions to integrate SSO with [meshStack Identity Federation](./meshstack.identity-federation.md).
+
+## Azure Kubernetes Services
+
+In order to use the AKS cluster properly with meshStack you need to enable the Azure AD integration. A good description on what needs to be done can be found in the [AKS-managed Azure Active Directory integration](https://docs.microsoft.com/en-us/azure/aks/managed-aad) document from Microsoft.
+
+You need the Azure CLI version 2.0.61 or later installed and configured. Run `az --version` to find the version. If you need to install or upgrade, see Install Azure CLI.
+
+After a successful replication, users can then fetch their `kubectl` credentials via:
+
+```bash
+az aks get-credentials --resource-group myResourceGroup --name myAKSCluster --overwrite-existing
 ```

--- a/docs/meshstack.kubernetes.landing-zones.md
+++ b/docs/meshstack.kubernetes.landing-zones.md
@@ -1,0 +1,18 @@
+---
+id: meshstack.kubernetes.landing-zones
+title: Landing Zones
+---
+
+The Kubernetes Landing Zone can be used to configure how Namspaces are created inside a shared Kubernetes Cluster.
+
+
+## meshRole to Platform Role Mapping
+
+The meshProject roles must be mapped to Kubernetes specific Cluster Roles. This cluster role is then assigned to the users for their namespace via a Role Binding.
+You are able to control this mapping with a Landing Zone setting. Usually its a good idea to setup own Cluster Roles in Kubernetes before and then map them to their
+meshStack counterpart. But you can also use predefined Kubernetes Cluster Roles like `editor` or `viewer`.
+
+## Resource Quota
+
+Kubernetes ResourceQuotas are used to limit the number of resources inside a namespace (which represents a meshProject). In this Landing Zone setting you can
+put in your Quotas.

--- a/docs/meshstack.kubernetes.metering.md
+++ b/docs/meshstack.kubernetes.metering.md
@@ -36,18 +36,13 @@ let PodResourceTraits =
       status:
         Status phase of this pod. See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
     -}
-    { milliCpu: Integer
-      , ramMb: Integer
-      , status: Text
-    }
+      { milliCpu : Integer, ramMb : Integer, status : Text }
 ```
 <!--Example-->
 ```dhall
-let example : PodResourceTraits =
-    { milliCpu = +2500
-      , ramMb = +1024
-      , status = "Running"
-    }
+let example
+    : PodResourceTraits
+    = { milliCpu = +2500, ramMb = +1024, status = "Running" }
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -69,17 +64,12 @@ let PersistentVolumeClaimResourceTraits =
       storageMb:
         Total Capacity of the Volume, in MiB.
     -}
-    { status: Text
-      , storageClassName: Text
-      , storageMb: Integer
-    }
+      { status : Text, storageClassName : Text, storageMb : Integer }
 ```
 <!--Example-->
 ```dhall
-let example : PersistentVolumeClaimResourceTraits =
-    { status = "Bound"
-      , storageClassName = "slow"
-      , storageMb = +5120
-    }
+let example
+    : PersistentVolumeClaimResourceTraits
+    = { status = "Bound", storageClassName = "slow", storageMb = +5120 }
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/meshstack.metadata-tags.md
+++ b/docs/meshstack.metadata-tags.md
@@ -159,25 +159,25 @@ let TenantTags =
         Using a prefix to identify this enables the customer to use own tags on resources which are not touched
         by meshstack.
 
-      tag-definitions[].name:
+      tag-mappers[].key:
         The name of the tag on the target platform. Every platform might have different limitations about the
         tag names.
 
-      tag-definitions[].value-pattern:
+      tag-mappers[].value-pattern:
         Define a pattern which is used to generate the tag value on the platform. Every platform might have different
         limitations about the tag values. For a list about the placeholder you can use please check the meshstack
         documentation. Currently its not possible to use more then one identifier per valuePattern.
     -}
       { namespace-prefix : Text
-      , tag-definitions : List { name : Text, value-pattern : Text }
+      , tag-mappers : List { key : Text, value-pattern : Text }
       }
 ```
 <!--Example-->
 ```dhall
 let example =
         { namespace-prefix = "meshstack_"
-        , tag-definitions =
-          [ { name = "cident", value-pattern = "prefix-\${customerIdentifier}" }
+        , tag-mappers =
+          [ { key = "cident", value-pattern = "prefix-\${customerIdentifier}" }
           ]
         }
       : TenantTags

--- a/docs/meshstack.openshift.metering.md
+++ b/docs/meshstack.openshift.metering.md
@@ -37,18 +37,13 @@ let PodResourceTraits =
       status:
         Status phase of this pod. See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
     -}
-    { milliCpu: Integer
-      , ramMb: Integer
-      , status: Text
-    }
+      { milliCpu : Integer, ramMb : Integer, status : Text }
 ```
 <!--Example-->
 ```dhall
-let example : PodResourceTraits =
-    { milliCpu = +2500
-      , ramMb = +1024
-      , status = "Running"
-    }
+let example
+    : PodResourceTraits
+    = { milliCpu = +2500, ramMb = +1024, status = "Running" }
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
@@ -70,17 +65,12 @@ let PersistentVolumeClaimResourceTraits =
       storageMb:
         Total Capacity of the Volume, in MiB.
     -}
-    { status: Text
-      , storageClassName: Text
-      , storageMb: Integer
-    }
+      { status : Text, storageClassName : Text, storageMb : Integer }
 ```
 <!--Example-->
 ```dhall
-let example : PersistentVolumeClaimResourceTraits =
-    { status = "Bound"
-      , storageClassName = "slow"
-      , storageMb = +5120
-    }
+let example
+    : PersistentVolumeClaimResourceTraits
+    = { status = "Bound", storageClassName = "slow", storageMb = +5120 }
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -91,7 +91,9 @@
     ],
     "Kubernetes": [
       "meshstack.kubernetes.index",
-      "meshstack.kubernetes.metering"
+      "meshstack.kubernetes.landing-zones",
+      "meshstack.kubernetes.metering",
+      "meshstack.kubernetes.config"
     ],
      "OpenShift": [
       "meshstack.openshift.index",
@@ -118,7 +120,7 @@
       "meshstack.email",
       "meshstack.logging",
       "meshstack.monitoring"
-      
+
     ]
   }
 }


### PR DESCRIPTION
I just realized, while writing and going through the Azure docs once more, I might have made a mistake while testing. Because in order to fetch the AKS credentals it seems the user need a special permission on the cluster resource itself. Which currently is not set via replication. I might was mislead because the user I used probably was an Admin/Owner on that resource and thus the fetching of creds just worked. Need to check that tomorrow and in that case we probably need one more replication step and I must adapt the docs.

But its quite finished beside that so I already open a draft PR.