### PR TITLE
fix: Snippet tool removing docs sections

### DIFF
--- a/snippets/src/main.ts
+++ b/snippets/src/main.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as process from 'process';
 
 import { snippets } from './extract';
+import { sanityCheck } from './sanity-check';
 import { SnippetRepository } from './SnippetRepository';
 import { SnippetsRenderer } from './SnippetsRenderer';
 import { update } from './update';
@@ -34,10 +35,12 @@ async function buildSnippetCache(srcGlob: string, repo: SnippetRepository) {
 export async function updateSnippets(srcPath: string, repo: SnippetRepository, renderer: SnippetsRenderer) {
   const content = await fs.promises.readFile(srcPath, 'utf8');
 
+  sanityCheck(content);
+
   const updatedContent = await update(content, repo, renderer);
 
   if (updatedContent !== content) {
-    console.log(`- updating snippet referenes in: ${srcPath}`);
+    console.log(`- updating snippet references in: ${srcPath}`);
     await fs.promises.writeFile(srcPath, updatedContent, 'utf8');
   }
 }
@@ -83,14 +86,14 @@ async function main(): Promise<number> {
   createSnippetCacheDir(snipsPath);
 
   if (src) {
-    const absoluteSrc = await path.resolve(src);
-    const absoluteSrcGlob = await path.join(absoluteSrc, srcGlob);
+    const absoluteSrc = path.resolve(src);
+    const absoluteSrcGlob = path.join(absoluteSrc, srcGlob);
     await buildSnippetCache(absoluteSrcGlob, repo);
   }
 
   if (docs) {
-    const absoluteDocs = await path.resolve(docs);
-    const absoluteDocsGlob = await path.join(absoluteDocs, docsGlob);
+    const absoluteDocs = path.resolve(docs);
+    const absoluteDocsGlob = path.join(absoluteDocs, docsGlob);
     await updateDocsSnippets(absoluteDocsGlob, repo);
   }
 

--- a/snippets/src/sanity-check.ts
+++ b/snippets/src/sanity-check.ts
@@ -1,0 +1,35 @@
+
+export function sanityCheck(
+  markdown: string,
+) {
+  const snippetRegexOpening = /<!--snippet:(.*)-->/gm;
+  const snippetRegexClosing = /<!--END_DOCUSAURUS_CODE_TABS-->/gm;
+
+  let mOpen: RegExpExecArray | null = null;
+  const openIdxs: number[] = [];
+  const closeIdxs: number[] = [];
+  const openTags: string[] = [];
+  while (null != (mOpen = snippetRegexOpening.exec(markdown))) {
+    openIdxs.push(mOpen.index);
+    openTags.push(mOpen[1]);
+  }
+  while (null != (mOpen = snippetRegexClosing.exec(markdown))) {
+    closeIdxs.push(mOpen.index);
+  }
+
+  for (let i = 0; i < closeIdxs.length; i++) {
+    const currentCloseIdx = closeIdxs[i];
+    const openedIdxBefore = openIdxs.filter(x => x < currentCloseIdx);
+    if (openedIdxBefore.length > 1) {
+      throw Error('ERROR: Tag \'' + openTags.shift() + '\' seems not to be closed with <!--END_DOCUSAURUS_CODE_TABS-->');
+    } else {
+      openIdxs.shift();
+      openTags.shift();
+    }
+  }
+
+  // Check if there are still opened tags.
+  if (openIdxs.length > 0) {
+    throw Error('ERROR: Tag \'' + openTags.shift() + '\' seems not to be closed with <!--END_DOCUSAURUS_CODE_TABS-->');
+  }
+}


### PR DESCRIPTION
If a closing tag of a snippet was missing there was the danger of the snippet tool
removing parts of the documentation without warning. Now an error is thrown.