### PR TITLE
added more detailed version support info for private cloud platforms

### DIFF
--- a/docs/meshstack.cloudfoundry.index.md
+++ b/docs/meshstack.cloudfoundry.index.md
@@ -19,6 +19,24 @@ The tenant [replication](./meshcloud.tenant.md) ensures spaces and orgs are crea
 
 ![Cloud Foundry Architecture](assets/cf-architecture.svg)
 
+## CloudFoundry Versions
+
+In general all CloudFoundry versions that provide the V2 API for the following endpoints are supported:
+
+* /v2/organizations
+* /v2/quota_definitions
+* /v2/space_quota_definitions
+* /v2/spaces
+* /v2/users
+* /v2/apps
+* /v2/private_domains
+* /v2/domains
+
+Integration with the following Cloud Foundry API Versions are additionally tested successfully:
+
+* 2.155.0
+* 2.181.0
+
 ## Cloud Foundry Access Workflow
 
 The full workflow to access the Cloud Foundry platform is as follows:

--- a/docs/meshstack.cloudfoundry.index.md
+++ b/docs/meshstack.cloudfoundry.index.md
@@ -19,23 +19,23 @@ The tenant [replication](./meshcloud.tenant.md) ensures spaces and orgs are crea
 
 ![Cloud Foundry Architecture](assets/cf-architecture.svg)
 
-## CloudFoundry Versions
+## Cloud Foundry Versions
+
+meshcloud officially validates compatibility with the following API versions:
+
+* `2.155.0`
+* `2.181.0`
 
 In general all CloudFoundry versions that provide the V2 API for the following endpoints are supported:
 
-* /v2/organizations
-* /v2/quota_definitions
-* /v2/space_quota_definitions
-* /v2/spaces
-* /v2/users
-* /v2/apps
-* /v2/private_domains
-* /v2/domains
-
-Integration with the following Cloud Foundry API Versions are additionally tested successfully:
-
-* 2.155.0
-* 2.181.0
+* `/v2/organizations`
+* `/v2/quota_definitions`
+* `/v2/space_quota_definitions`
+* `/v2/spaces`
+* `/v2/users`
+* `/v2/apps`
+* `/v2/private_domains`
+* `/v2/domains`
 
 ## Cloud Foundry Access Workflow
 

--- a/docs/meshstack.kubernetes.index.md
+++ b/docs/meshstack.kubernetes.index.md
@@ -30,7 +30,7 @@ meshStack should work with any Kubernetes version and distribution that offers t
 - `core/v1`
 - `rbac.authorization.k8s.io/v1`
 
-meshStack has been specifically validated to work with RKE (Rancher Kubernetes Enginge) and CFCR (Cloud Foundry Container Runtime).
+meshStack has been specifically validated to work with RKE (Rancher Kubernetes Engine), [AKS](#azure-kubernetes-services) (Azure Kubernetes Cluster) and CFCR (Cloud Foundry Container Runtime).
 
 ### meshStack Configuration
 

--- a/docs/meshstack.openshift.index.md
+++ b/docs/meshstack.openshift.index.md
@@ -15,7 +15,12 @@ To enable integration with OpenShift, operators deploy and configure the meshSta
 
 ### OpenShift Versions
 
-meshStack currently supports OpenShift version 3.9+ as either Open-Source (OKD) or OpenShift Enterprise variants.
+meshStack currently supports OpenShift version 3.9+ and 4.x as either Open-Source (OKD) or OpenShift Enterprise variants.
+
+In general meshStack supports all OpenShift versions that can provide the resources listed for the required [service accounts](meshstack.openshift.index.md#meshstack-service-accounts). These resources are consumed with the following versions. So as long as the following endpoints are supported in the OpenShift version, meshStack should be able to work with it:
+
+* /api/v1
+* /apis/template.openshift.io/v1
 
 ### IdP Configuration
 

--- a/docs/meshstack.openshift.index.md
+++ b/docs/meshstack.openshift.index.md
@@ -15,12 +15,12 @@ To enable integration with OpenShift, operators deploy and configure the meshSta
 
 ### OpenShift Versions
 
-meshStack currently supports OpenShift version 3.9+ and 4.x as either Open-Source (OKD) or OpenShift Enterprise variants.
+meshStack currently officially supports and validates OpenShift version 4.x as either Open-Source (OKD) or OpenShift Enterprise variants. Also version 3.9+ was successfully validated in the past with meshStack and should still be working, but it is no longer officially validated by meshcloud.
 
-In general meshStack supports all OpenShift versions that can provide the resources listed for the required [service accounts](meshstack.openshift.index.md#meshstack-service-accounts). These resources are consumed with the following versions. So as long as the following endpoints are supported in the OpenShift version, meshStack should be able to work with it:
+In general meshStack supports all OpenShift versions that can provide the resources listed for the required [service accounts](meshstack.openshift.index.md#meshstack-service-accounts). These resources are consumed with the versions mentioned in the cluster roles of the service account or if not defined there with the following versions:
 
-* /api/v1
-* /apis/template.openshift.io/v1
+* [`/api/v1`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/)
+* [`/apis/template.openshift.io/v1`](https://docs.openshift.com/container-platform/4.7/rest_api/template_apis/template-template-openshift-io-v1.html)
 
 ### IdP Configuration
 

--- a/docs/meshstack.openstack.index.md
+++ b/docs/meshstack.openstack.index.md
@@ -19,19 +19,20 @@ The backend also uses the JWT token to check the user's permissions. If the perm
 
 meshStack currently fully supports OpenStack Ocata, Pike and Queens. Replication and Metering is also officially supported up to OpenStack Ussuri. For the versions beyond Queens the meshPanel integration of workload management in OpenStack can not be guaranteed.
 
-In general all versions providing the following APIs should be working fine with meshStack:
+For Replication to work, only `KeystonV3` API must be available. For full metering support and meshPanel integration the following APIs are required:
 
-* KeystoneV3
-* CinderV3
-* Neutron v2.0
-* Glance V2
+* `KeystoneV3`
+* `CinderV3`
+* `Neutron v2.0`
+* `Glance V2`
 
-Additionally the following OpenStack services are used, but not explicitly versioned by OpenStack:
+Additionally the following OpenStack APIs are used without specific major version requirements. Still, the specific microversion of these services must support the calls listed here.
 
-* Nova: list servers & VM flavors
-* Swift or Radosgw-Swift: list Object Storages, via meshPanel also creation of those
-* Heat: list Heat Stacks
-* Designate: list DNS Zones
+* `Nova`: List servers & VM flavors; create servers via meshPanel
+* `Swift or Radosgw-Swift`: List Object Storages; create Object Storages via meshPanel
+* `Heat`: List Heat Stacks for resource check and metering
+* `Designate`: List DNS Zones for resource check and metering
+* `Panko` (optional): List events about resource lifecycle to provide more fine-grained metering
 
 ## OpenStack Access
 

--- a/docs/meshstack.openstack.index.md
+++ b/docs/meshstack.openstack.index.md
@@ -15,6 +15,24 @@ The backend also uses the JWT token to check the user's permissions. If the perm
 
 ![OpenStack Architecture](assets/os-architecture.png)
 
+## OpenStack Versions
+
+meshStack currently fully supports OpenStack Ocata, Pike and Queens. Replication and Metering is also officially supported up to OpenStack Ussuri. For the versions beyond Queens the meshPanel integration of workload management in OpenStack can not be guaranteed.
+
+In general all versions providing the following APIs should be working fine with meshStack:
+
+* KeystoneV3
+* CinderV3
+* Neutron v2.0
+* Glance V2
+
+Additionally the following OpenStack services are used, but not explicitly versioned by OpenStack:
+
+* Nova: list servers & VM flavors
+* Swift or Radosgw-Swift: list Object Storages, via meshPanel also creation of those
+* Heat: list Heat Stacks
+* Designate: list DNS Zones
+
 ## OpenStack Access
 
 1. The user accesses the meshStack via the browser.
@@ -43,9 +61,9 @@ As OpenStack has to scope authorization to a specific project, the token from th
 
 Project Users get the following OpenStack roles:
 
-- _member_
-- heat_stack_owner
-- creator
+* _member_
+* heat_stack_owner
+* creator
 
 The actual access rights associated with these roles are managed by the OpenStack instance and are not part of meshStack.
 


### PR DESCRIPTION
I added more information around version requirements for private cloud platforms. I only added information that was retrievable with a reasonable amount of effort.

For OSB we already mention the version we support.

For public cloud platforms i don't see what should be documented around this. Mentioning some kind of root access to the platform as a prerequisite doesn't make too much sense for me. If there is additional information known by the solutions flock that should be documented, please feel free to extend this PR accordingly.