### PR TITLE
fix: use correct robots.txt on netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,19 +13,22 @@
   publish = "build/meshcloud-docs"
 
   # Default build command.
-  command = "sed -i \"s|API_DOCS_DOMAIN_PLACEHOLDER|${API_DOCS_DOMAIN}|g\" ../netlify.toml && yarn build"
+  # note: this replaces contents in _this_!! file, especially the domain redirects
+  command = "sed -itoml \"s|API_DOCS_DOMAIN_PLACEHOLDER|${API_DOCS_DOMAIN}|g\" ../netlify.toml && yarn build:develop"
 
   # This ensures the build is ignored if there are no changes to the base or /docs/ directory.
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../docs/ ../netlify.toml"
 
 [context.production]
-  ignore = "exit 1"
+  # for production, we need to run the build:master commmand 
+  command = "sed -itoml \"s|API_DOCS_DOMAIN_PLACEHOLDER|${API_DOCS_DOMAIN}|g\" ../netlify.toml && yarn build:master"
+  ignore = "exit 1" # never ignore a build
 
 [context.production.environment]
   API_DOCS_DOMAIN = "meshcloud"
 
 [context.branch-deploy]
-  ignore = "exit 1"
+  ignore = "exit 1" # never ignore a build
 
 [context.branch-deploy.environment]
   API_DOCS_DOMAIN = "dev.meshcloud"

--- a/website/package.json
+++ b/website/package.json
@@ -3,10 +3,10 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
-    "build": "run-s lint build:develop",
     "build:master": "DOCSEARCH_INDEXNAME='meshcloud' DOCSEARCH_APIKEY='1b6387d9fcda3cba4cdb3ffb68cde260' docusaurus-build",
     "postbuild:master": "cp robots.master.txt build/meshcloud-docs/robots.txt",
     "build:develop": "DOCSEARCH_INDEXNAME='meshcloud_dev' DOCSEARCH_APIKEY='651f9d1e5d32c2a465935a001a047407' docusaurus-build",
+    "prebuild:develop": "run-s lint",
     "postbuild:develop": "cp robots.develop.txt build/meshcloud-docs/robots.txt",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",


### PR DESCRIPTION
We need to build with either build:master or build:deploy to handle
robots.txt correctly. Removed the "build" command to cut out any chance
of confusion.