### PR TITLE
fix: Move customer name to correct YAML field in owner change guide

### DIFF
--- a/docs/meshstack.how-to.change-customer-owner.md
+++ b/docs/meshstack.how-to.change-customer-owner.md
@@ -38,8 +38,8 @@ curl --location --request PUT 'https://backend-url/api/meshobjects?meshObjectCol
 kind: meshCustomerUserBinding
 roleRef:
   name: Customer Owner
-targetRef: my-customer
-  name:
+targetRef:
+  name: my-customer
 subjects:
   - name: partner@meshcloud.io'
 ```


### PR DESCRIPTION
Without this fix, the YAML payload would be rejected by the server.

Signed-off-by: Marius Kießling <marius.kiessling@metro.digital>