### PR TITLE
docs: fix instruction text around navigation to the marketplace

### DIFF
--- a/docs/meshstack.meshmarketplace.development.md
+++ b/docs/meshstack.meshmarketplace.development.md
@@ -3,21 +3,26 @@ id: meshstack.meshmarketplace.development
 title: Marketplace Development
 ---
 
-You can provide your own services in the [meshMarketplace](marketplace.index.md) via the Marketplace Development. The functionality is currently
-only available for [Customer Admins](meshcloud.customer.md#manage-groups-of-assigned-users).
-You can provide your service (e.g. databases, message brokers, filesystems, etc) by implementing the [Open Service Broker API](https://www.openservicebrokerapi.org/). Your implementation of an application that manages these services is called a Service Broker. Services provided by you can be consumed by other users of the meshPortal. A short overview and some specifics that should be considered when writing a Service Broker for the meshMarketplace are described [here](meshstack.meshmarketplace.index.md).
+> Only users with the role [Customer Admin](meshcloud.customer.md#assign-meshcustomer-roles) or [Customer Owner](meshcloud.customer.md#assign-meshcustomer-roles) have access to the administrative functionality described in this section.
+
+You can provide your own services (e.g. databases, message brokers, filesystems, etc) in the [meshMarketplace](marketplace.index.md) via the **Marketplace** >  **Service Brokers** on your [customer control plane](./meshcloud.customer.md#managing-your-meshcustomer). This requires you have a running Service Broker, an application that manages these services by the means of [Open Service Broker API](https://www.openservicebrokerapi.org/). Services provided by you can then be consumed by other users in the meshPanel. A short overview and some specifics that should be considered when writing a Service Broker for the meshMarketplace are described [here](meshstack.meshmarketplace.index.md).
 
 meshStack supports OSB Version 2.14 and is on the way to support OSB 2.15.
 
-## Marketplace Development
+## Marketplace
 
-You can find the **Marketplace Development** in your [meshCustomer Control Plane](./meshcloud.customer.md#managing-your-meshcustomer). Via the **Service Broker** section in the navigation on the left, you get to the maintenance area for your service brokers. You can register and publish your Service Broker. [Analytics](#debugging-your-service-broker) screens that provide you with Usage and Logging Data are also available.
+You can find the **Marketplace** tab on your [customer control plane](./meshcloud.customer.md#managing-your-meshcustomer). Via **Service Brokers** tab, you get to the maintenance area for your service brokers. You can register and publish your Service Broker. [Analytics](#debugging-your-service-broker) screens that provide you with Usage and Logging Data are also available.
 
 ### Register your Service Broker
 
 Registering your Service Broker does not publish your Service Broker directly for all users. Initially only your meshCustomer will have access to this Service Broker. We call this type of Service Broker a **private Service Broker**. It allows you to test and develop your Service Broker via the meshMarketplace development from the first steps on. A new Marketplace Platform for your Customer will be available for your [projects](meshcloud.project.md#adding-meshtenants) after registering a Service Broker. When you select it for a project, your own Marketplace will be available on the project.
 
-You can register your service broker via the **Register Service Broker** button. The following information must be provided for this:
+
+1. Open **Marketplace** on your [customer control plane](./meshcloud.customer.md#managing-your-meshcustomer).
+2. Navigate to the **Service Brokers** tab.
+3. Click `+ Register` in the upper right corner.
+
+The following information must be provided for the registration:
 
 - **Name**: Give a name to the service broker you want to register. It is mainly used as a display name for your administrative Screens.
 - **Identifier**: Globally unique, immutable identifier for your Service Broker, used in API requests and logs by meshStack. Choose wisely as *this identifier cannot be changed later* on. We advise to use meaningful and expressive identifiers.
@@ -36,7 +41,7 @@ Service Brokers provide the catalog of all available service according to the [O
 
 ## Publish your Service Broker
 
-As soon as your Service Broker is production-ready, you can publish it to the public meshMarketplaces, so all users of the meshPortal can use it. You should provide a new deployment of your Service Broker in order to publish it. Your private service broker configuration will remain untouched when publishing the service broker. The private Service Broker will still be available for your meshCustomer.
+As soon as your Service Broker is production-ready, you can publish it to the public meshMarketplaces, so all users of meshStack can use it. You should provide a new deployment of your Service Broker in order to publish it. Your private service broker configuration will remain untouched when publishing the service broker. The private Service Broker will still be available for your meshCustomer.
 
 To publish your Service Broker, click the **Publish Service Broker** button for the according Service Broker.
 
@@ -97,7 +102,7 @@ Searching the communication logs to e.g. find a specific issue that was reported
 
 The deletion of a Service Broker is only allowed if it has not been [published](#publish-your-service-broker) and [approved](administration.service-brokers.md#approve-service-broker). As soon as an approved Service Broker exists users can create Service Instances from your services. The deletion of a Service Broker could affect productive data of other users and is therefore not possible.
 
-Unpublished, unapproved Service Brokers can be deleted from the list of Service Brokers via the **trash** button. A safety dialogue pops up, where you have to enter the name of the Service Broker for confirmation. The deletion will only delete the Service Broker in the meshPortal. **No deprovisioning** will be triggered in the Service Broker! You have to clean up existing Service Instances in your Service Broker by yourself!
+Unpublished, unapproved Service Brokers can be deleted from the list of Service Brokers via the **trash** button. A safety dialogue pops up, where you have to enter the name of the Service Broker for confirmation. The deletion will only delete the Service Broker in the meshStack. **No deprovisioning** will be triggered in the Service Broker! You have to clean up existing Service Instances in your Service Broker by yourself!
 
 After you have published your Service Broker you can also revoke this publishing by clicking the **trash** icon in the Publishing list of your Service Broker as long as it has not been approved.
 


### PR DESCRIPTION
fix instruction text around navigation to the marketplace as we notice in our workshop that it is not up to date anymore
Before:
![image](https://user-images.githubusercontent.com/64793818/217477262-f5f46036-d43f-46eb-9bc4-7e982114390c.png)


After:
![image](https://user-images.githubusercontent.com/64793818/217477183-9b79cc50-4388-49f9-8f70-a49a6fd4f0b4.png)
