### PR TITLE
chore: remove obsolete info about payment method type

### DIFF
--- a/docs/meshcloud.payment-methods.md
+++ b/docs/meshcloud.payment-methods.md
@@ -31,11 +31,10 @@ One way of creating payment methods is via the meshPanel. To do so, make sure th
 
 3. Click on 'Create Payment Method' at the top right.
 4. Enter a name and identifier for the new payment method.
-5. Choose a type for the payment method. Read more [here](#types-of-payment-methods) on what type to choose and what the individual differences are.
-6. (This is optional) Set a maximum amount of EUR on the payment method to indicate the remaining budget of this payment method.
-7. (This is optional) Set an expiration date for the payment method. This is especially useful when a budget expires, e.g. at the end of the accounting year.
-8. Additionally, you can enter tags for the payment method, which are custom for your meshStack (also see [meshTags](meshstack.metadata-tags.md)). This is useful when you want to enhance the payment method with organizational details like the cost center number or the business unit.
-9. Click 'Save' and your new payment method will be available to the meshCustomer it was created in!
+5. (This is optional) Set a maximum amount of EUR on the payment method to indicate the remaining budget of this payment method.
+6. (This is optional) Set an expiration date for the payment method. This is especially useful when a budget expires, e.g. at the end of the accounting year.
+7. Additionally, you can enter tags for the payment method, which are custom for your meshStack (also see [meshTags](meshstack.metadata-tags.md)). This is useful when you want to enhance the payment method with organizational details like the cost center number or the business unit.
+8. Click 'Save' and your new payment method will be available to the meshCustomer it was created in!
 
 ### Creating a Payment Method via the meshObject API
 


### PR DESCRIPTION
Removed the fifth entry that describes to select the payment method type.

As discussed in slack:

> In the past we had this as a direct field on the payment method. But it doe snot exist anymore. So we just have to remove it from the public docs. 