### PR TITLE
docs: clarify meshLandingZone mapping and configuration

### DIFF
--- a/docs/meshstack.index.md
+++ b/docs/meshstack.index.md
@@ -2,6 +2,7 @@
 id: meshstack.index
 title: Overview
 ---
+
 <h3 style="margin-top: 0">Welcome to the meshStack Documentation!</h3>
 
 meshStack is the name of our technology that powers the meshcloud solution. This document is targeted at cloud architects and SREs and introduces the components of meshStack and their interaction.
@@ -30,16 +31,15 @@ These mappings can be customized. For more details, please consult documentation
 
 The connections are shown in the following matrix table:
 
-|               | [meshWorkspace](./meshcloud.workspace.md) | [meshProject](./meshcloud.project.md) | [meshUser](./meshcloud.profile.md) | [Landing Zone](./meshcloud.landing-zones.md) |
-| :-----------: | :-------------------------------------: | :-----------------------------------: | :--------------------------------: | :-----------------------------------------: |
-|   OpenStack   |              Domain (optional)          |                Project                |        Keystone Shadow User        |                    Quota                    |
-| Cloud Foundry |              Organization               |                 Space                 |              UAA User              |                    Quota                    |
-|  Kubernetes   |                    -                    |               Namespace               |            Rolebinding             |               YAML Templates                |
-|   OpenShift   |                    -                    |                Project                |                User                |               YAML Templates                |
-|      AWS      |                    -                    |                Account                |              IAM Role              |      CF StackSets / Organization Units      |
-|     Azure     |                    -                    |             Subscription              |              AAD User              |        Blueprints / Management Groups        |
-|      GCP      |                    -                    |                Project                |              GCD User              |     Organization Policy / GDM Template      |
-
+|               | [meshWorkspace](./meshcloud.workspace.md) | [meshProject](./meshcloud.project.md) | [meshUser](./meshcloud.profile.md) | [meshLandingZone](./meshcloud.landing-zones.md) |
+| :-----------: | :---------------------------------------: | :-----------------------------------: | :--------------------------------: | :------------------------------------------: |
+|   OpenStack   |             Domain (optional)             |                Project                |        Keystone Shadow User        |                    Quota                     |
+| Cloud Foundry |               Organization                |                 Space                 |              UAA User              |                    Quota                     |
+|  Kubernetes   |                     -                     |               Namespace               |            Rolebinding             |                YAML Templates                |
+|   OpenShift   |                     -                     |                Project                |                User                |                YAML Templates                |
+|      AWS      |                     -                     |                Account                |              IAM Role              |      Organization Units / CF StackSets       |
+|     Azure     |                     -                     |             Subscription              |              AAD User              |        Management Groups / Blueprints        |
+|      GCP      |                     -                     |                Project                |              GCD User              |           Folders / GDM Templates            |
 
 ## Operations
 
@@ -47,6 +47,7 @@ meshcloud will typically operate your meshStack installation as a [managed servi
 
 ### Configuration
 
-meshcloud configures your meshStack installation using a [dhall](https://dhall-lang.org/) configuration model. As part of meshcloud's managed service, customers get access to their configuration in a git repository. This is also useful to communicate configuration options and track changes.
+Most of meshStack's configuration can be done in self-service via the meshPanel in the Administration area.
 
-The configuration documentation will occasionally also make references to [YAML](https://en.wikipedia.org/wiki/YAML) configuration options. These will be replaced with `dhall` models in the next releases. Dhall models can generate YAML configuration files dynamically, but provide superior features in terms of flexibility and validation.
+meshStack also supports advanced configuration options. Please see [managed service](./meshstack.managed-service.md) for more details.
+

--- a/docs/meshstack.managed-service.md
+++ b/docs/meshstack.managed-service.md
@@ -18,7 +18,7 @@ However, some advanced product functionality is currently only available via a c
 When applicable to your chosen meshStack plan, meshcloud can make the configuration model of your meshStack instance available to you as a git repository.
 This is useful to track configuration changes, for example to integrate with a change management process.
 
-To request advanced configuration changes for your meshStack instance, please contact your contact from customer sucess or support@meshcloud.io.
+To request advanced configuration changes for your meshStack instance, please contact your contact from customer success or support@meshcloud.io.
 
 ### Versioning & Continuous Delivery
 

--- a/docs/meshstack.managed-service.md
+++ b/docs/meshstack.managed-service.md
@@ -13,11 +13,12 @@ which can be either [meshStack SaaS](#meshstack-saas) or [meshStack Enterprise](
 ### Configuration
 
 Most of meshStack's configuration can be done in self-service via the meshPanel in the Administration area.
-However, there might be some product functionality which has to be configured by meshcloud in the configuration as
-code repository. To do so, please contact support@meshcloud.io.
+However, some advanced product functionality is currently only available via a configuration as code model based on [dhall](https://dhall-lang.org/).
 
-It will be clear from the designated product documentation page whether the feature can be configured in self-service
-or via the configuration as code repository.
+When applicable to your chosen meshStack plan, meshcloud can make the configuration model of your meshStack instance available to you as a git repository.
+This is useful to track configuration changes, for example to integrate with a change management process.
+
+To request advanced configuration changes for your meshStack instance, please contact your contact from customer sucess or support@meshcloud.io.
 
 ### Versioning & Continuous Delivery
 


### PR DESCRIPTION
- we no longer have any yaml configuration references in docs
- remove duplicate descriptions of how to access dhall configuration, move all of this to the managed-service page