### PR TITLE
feat: update g-suite reference to use google workplace name

### DIFF
--- a/docs/meshstack.gcp.index.md
+++ b/docs/meshstack.gcp.index.md
@@ -12,7 +12,7 @@ meshcloud can automatically provision GCP Projects as Tenants for [meshProjects]
 To enable integration with GCP, operators need to deploy and configure the meshStack GCP Replicator. Operators can configure one or multiple `PlatformInstance`s of `PlatformType.GCP`. This makes GCP available to meshProjects like any other cloud platform in meshStack.
 
 Google Cloud Platform relies on [Google Cloud Identity (GCI)](https://cloud.google.com/identity/) for authentication and authorization. meshStack can seamlessly integrate with GCI and various hybrid identity setups.
-Organizations already using Google Cloud Directory Sync or G-Suite can use meshStack with an [externally provisioned identities](./meshstack.identity-federation.md) configuration.
+Organizations already using Google Cloud Directory Sync or Google Workspace can use meshStack with an [externally provisioned identities](./meshstack.identity-federation.md) configuration.
 
 meshcloud helps organizations implement Google Cloud Platform in line with [governance best-practices](https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations) by integrating with the GCP [Organization Resource Hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy) and [Organization Policy Service](https://cloud.google.com/resource-manager/docs/organization-policy/overview) using [Landing Zones](./meshstack.gcp.landing-zones.md).
 
@@ -22,7 +22,7 @@ In order to plan and execute a successful integration of GCP using meshcloud, or
 
 ## Cloud Identity Setup
 
-Cloud Identity "Free" is sufficient for automated GCP IAM management through meshStack. meshStack does not require Cloud Identity Premium nor G-Suite features.
+Cloud Identity "Free" is sufficient for automated GCP IAM management through meshStack. meshStack does not require Cloud Identity Premium nor Google Workspace features.
 
 We recommend using [externally provisioned identities](./meshstack.identity-federation.md) with GCP.
 

--- a/docs/meshstack.identity-federation.md
+++ b/docs/meshstack.identity-federation.md
@@ -86,7 +86,7 @@ graph LR;
 
 ### Externally-provisioned Identities
 
-Some public cloud platforms like [Microsoft Azure](./meshstack.azure.index.md) or [Google Cloud Platform](./meshstack.gcp.index.md) feature their own directory services for cloud-based or hybrid user identities. Enterprises provision cloud identities by synchronizing an on-premise directory to the cloud. These setups are especially common for enterprises using Office 365 or Google G-Suite.
+Some public cloud platforms like [Microsoft Azure](./meshstack.azure.index.md) or [Google Cloud Platform](./meshstack.gcp.index.md) feature their own directory services for cloud-based or hybrid user identities. Enterprises provision cloud identities by synchronizing an on-premise directory to the cloud. These setups are especially common for enterprises using Office 365 or Google Google Workspace.
 
 meshStack supports using user identities from these cloud directories for the resepective cloud [meshPlatform](./meshcloud.platforms.md). meshStack calls these **externally provisioned user identities** because provisioning and identity federation between on-premise and cloud-directory happens outside of meshStack.
 


### PR DESCRIPTION
g-suite has been renamed in ~2020 to google workplace