### PR TITLE
docs: align platform descriptions for capabilities and configuration

### DIFF
--- a/docs/meshstack.aws.index.md
+++ b/docs/meshstack.aws.index.md
@@ -3,17 +3,12 @@ id: meshstack.aws.index
 title: Integration
 ---
 
-AWS is a proprietary public cloud platform provided by Amazon Web Services. meshStack supports project and user management for AWS to include AWS services into cloud projects managed by meshStack.
-
-meshStack supports project creation, configuration, user management and SSO for AWS.
+AWS is a public cloud platform provided by Amazon Web Services.
+meshStack supports account creation, configuration, access control and cost management for AWS.
 
 ## Integration Overview
 
-To enable integration with AWS, Operators deploy and configure the meshStack AWS Connector. Operators can configure one or multiple `PlatformInstance`s of `PlatformType` AWS. In a typical setup, we recommend grouping each AWS `PlatformInstance` in a separate `Location`.
-
-This makes AWS available to meshProjects like any other cloud platform in meshStack.
-
-meshStack automatically configures AWS IAM in all managed accounts to integrate SSO with [meshStack Identity Federation](./meshstack.identity-federation.md).
+To enable integration with AWS, operators configure one or multiple `meshPlatform`s of `PlatformType` AWS in the [Platform Administration](./administration.platforms.md) in meshPanel.
 
 meshStack uses [AWS Organizations](https://aws.amazon.com/organizations/) to provision and manage AWS Accounts for [meshProjects](./meshcloud.project.md). To use AWS with a meshStack deployment, operators will need an AWS [management account](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_getting-started_concepts.html) acting as the parent of all accounts managed by meshStack. The complete meshStack setup contains three dedicated accounts:
 
@@ -41,7 +36,7 @@ graph LR;
 
 ### IAM Roles and Service Control Policies
 
-When a user (e.g. a developer) accesses an AWS Account, they are assigned an AWS IAM role based on their project role configured on the corresponding meshProject. Operators can configure these roles and their permissions by providing an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template. meshStack uses this template to initialize and update AWS Account configurations.
+meshStack replicates meshProject roles as AWS IAM roles to AWS SSO. Operators can configure the mapping of these roles via meshLandingZones.
 
 When configuring these roles, operators must take care to correctly guard against privilege escalation and maintain project sandboxing. Operators should also consider leveraging [Service Control Policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html) to simplify role configuration and set up a guarded boundary for the maximum of permissions granted to any role.
 

--- a/docs/meshstack.azure.index.md
+++ b/docs/meshstack.azure.index.md
@@ -3,12 +3,12 @@ id: meshstack.azure.index
 title: Integration
 ---
 
-meshcloud can automatically provision Azure Subscriptions as Tenants for [meshProjects](./meshcloud.project.md) and configure them according to your organiziations policies
+meshStack can automatically provision Azure Subscriptions or Resource Groups as Tenants for [meshProjects](./meshcloud.project.md) and configure them according to your organiziations policies
 using [Landing Zones](./meshcloud.landing-zones.md).
 
 ## Integration Overview
 
-To enable integration with Azure, operators need to deploy and configure the meshStack Azure Replicator. Operators can configure one or multiple `PlatformInstance`s of `PlatformType.Azure`. This makes Azure available to meshProjects like any other cloud platform in meshStack.
+To enable integration with Azure, operators configure one or multiple `meshPlatform`s of `PlatformType` Azure in the [Platform Administration](./administration.platforms.md) in meshPanel.
 
 Azure relies on Azure Active Directoy (AAD) for authentication and authorization. meshcloud can seamlessly integrate with common
 setups like [Azure Hybrid Identity](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/). meshcloud helps you implement Azure in line with [Governance best-practices](https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/govern/governance-disciplines) by integrating [Blueprints](https://docs.microsoft.com/en-us/azure/governance/blueprints/overview) and Management Groups using [Landing Zones](#landing-zones)

--- a/docs/meshstack.gcp.index.md
+++ b/docs/meshstack.gcp.index.md
@@ -3,13 +3,14 @@ id: meshstack.gcp.index
 title: Integration
 ---
 
-meshcloud can automatically provision GCP Projects as Tenants for [meshProjects](./meshcloud.project.md) and configure them according to your organizations policies using [Landing Zones](./meshcloud.landing-zones.md).
+Google Cloud Platform (GCP) is a public cloud platform provided by Google.
+meshStack supports project creation, configuration, access control and cost management for GCP.
 
 ## Integration Overview
 
 > The recommended way to set up GCP as a meshPlatform is via the public terraform [GCP meshPlatform Module](https://github.com/meshcloud/terraform-gcp-meshplatform). If you decide to use it, you do not need the steps below.
 
-To enable integration with GCP, operators need to deploy and configure the meshStack GCP Replicator. Operators can configure one or multiple `PlatformInstance`s of `PlatformType.GCP`. This makes GCP available to meshProjects like any other cloud platform in meshStack.
+To enable integration with GCP, operators configure one or multiple `meshPlatform`s of `PlatformType` GCP in the [Platform Administration](./administration.platforms.md) in meshPanel.
 
 Google Cloud Platform relies on [Google Cloud Identity (GCI)](https://cloud.google.com/identity/) for authentication and authorization. meshStack can seamlessly integrate with GCI and various hybrid identity setups.
 Organizations already using Google Cloud Directory Sync or Google Workspace can use meshStack with an [externally provisioned identities](./meshstack.identity-federation.md) configuration.

--- a/docs/meshstack.openshift.index.md
+++ b/docs/meshstack.openshift.index.md
@@ -5,11 +5,11 @@ title: Integration
 
 meshStack supports management of RedHat OpenShift platforms. OpenShift has a [Kubernetes](meshstack.kubernetes.index.md) core and provides additional services. It is available in both Open Source flavors (OKD) as well as enterprise offerings by RedHat.
 
-meshStack supports project creation, configuration and user management for OpenShift.
+meshStack supports project creation, configuration, access control, quota management and billing for OpenShift.
 
 ## Integration Overview
 
-To enable integration with OpenShift, operators deploy and configure the meshStack OpenShift Connector. Operators can configure one or multiple `PlatformInstance`s of `PlatformType` OpenShift. This makes OpenShift available to meshProjects like any other cloud platform in meshStack.
+To enable integration with OpenShift, operators configure one or multiple `meshPlatform`s of `PlatformType` OpenShift in the [Platform Administration](./administration.platforms.md) in meshPanel.
 
 ## Prerequisites
 


### PR DESCRIPTION
- align descriptions of capabilities supported by meshStack
- clarify language about platform connectors and self-service config