### PR TITLE
fix: Algolia search works again

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
-    "build:master": "DOCSEARCH_INDEXNAME='meshcloud' DOCSEARCH_APIKEY='1b6387d9fcda3cba4cdb3ffb68cde260' docusaurus-build",
+    "build:master": "DOCSEARCH_INDEXNAME='meshcloud' DOCSEARCH_APIKEY='aa3b874dff5c832fe2e3ed42a8062160' DOCSEARCH_APP_ID='LDDGX81P02' docusaurus-build",
     "postbuild:master": "cp robots.master.txt build/meshcloud-docs/robots.txt",
-    "build:develop": "DOCSEARCH_INDEXNAME='meshcloud_dev' DOCSEARCH_APIKEY='651f9d1e5d32c2a465935a001a047407' docusaurus-build",
+    "build:develop": "DOCSEARCH_INDEXNAME='meshcloud_dev' DOCSEARCH_APIKEY='97ab0f20a3d4208be89e9f23d2bc9787' DOCSEARCH_APP_ID='LUMRH2SV4Z' docusaurus-build",
     "postbuild:develop": "cp robots.develop.txt build/meshcloud-docs/robots.txt",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -134,6 +134,7 @@ const siteConfig = {
 
   algolia: {
     apiKey: process.env.DOCSEARCH_APIKEY,
+    appId: process.env.DOCSEARCH_APP_ID,
     indexName: process.env.DOCSEARCH_INDEXNAME
   },
 


### PR DESCRIPTION
* I am not sure how this worked initially but I found the two indexes on Algolia and pointed to their App IDs & API Key
* I changed the code in the Crawler so it correctly picks up headers (https://github.com/facebook/docusaurus/issues/6432)
* I changed in general some of the URLs that were pointed to in the Crawler.


All in all this seems to work now. You can run `yarn build:master` locally and serve the build and it will work :-)

Demo: https://jmp.sh/erIJKzE9