### PR TITLE
feat: add building block permissions to admin role overview

### DIFF
--- a/docs/administration.index.md
+++ b/docs/administration.index.md
@@ -64,6 +64,11 @@ per meshcloud installation.
 | [API Users](administration.apiusers.md)                                                                                 |       &#10003;       |            |                   |             |            |                    |                    |                      |
 | [Service&nbsp;Broker](administration.service-brokers.md)                                                                  |       &#10003;       |       &#10003;       |                   |             |            |                    |                    |                      |
 | &nbsp;&nbsp;[Approve&nbsp;Service&nbsp;Broker](administration.service-brokers.md#approve-service-broker)                  |       &#10003;       |       &#10003;       |                   |             |            |                    |                    |                      |
+| [List Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions](administration.building-blocks.md)     | &#10003; | &#10003; | &#10003; | &#10003; | | | | &#10003; |
+| &nbsp;&nbsp;&nbsp;Manage&nbsp;Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions     | &#10003; | &#10003; | &#10003; | &#10003; | | | | &#10003;|
+| &nbsp;&nbsp;&nbsp;Delete&nbsp;Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions     | &#10003; | &#10003; | &#10003; | | | | |                    
+
+
 
 Please review [meshWorkspace roles](meshcloud.workspace.md#assign-meshworkspace-roles) for roles available to end-users of your meshStack implementation.
 

--- a/docs/administration.index.md
+++ b/docs/administration.index.md
@@ -65,8 +65,8 @@ per meshcloud installation.
 | [Service&nbsp;Broker](administration.service-brokers.md)                                                                  |       &#10003;       |       &#10003;       |                   |             |            |                    |                    |                      |
 | &nbsp;&nbsp;[Approve&nbsp;Service&nbsp;Broker](administration.service-brokers.md#approve-service-broker)                  |       &#10003;       |       &#10003;       |                   |             |            |                    |                    |                      |
 | [List Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions](administration.building-blocks.md)     | &#10003; | &#10003; | &#10003; | &#10003; | | | | &#10003; |
-| &nbsp;&nbsp;&nbsp;Manage&nbsp;Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions     | &#10003; | &#10003; | &#10003; | &#10003; | | | | &#10003;|
-| &nbsp;&nbsp;&nbsp;Delete&nbsp;Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions     | &#10003; | &#10003; | &#10003; | | | | |                    
+| &nbsp;&nbsp;&nbsp;[Manage&nbsp;Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions](administration.building-blocks.md)     | &#10003; | &#10003; | &#10003; | &#10003; | | | | &#10003;|
+| &nbsp;&nbsp;&nbsp;[Delete&nbsp;Building&nbsp;Blocks&nbsp;&amp;&nbsp;Definitions](administration.building-blocks.md)     | &#10003; | &#10003; | &#10003; | | | | |                    
 
 
 


### PR DESCRIPTION
![image](https://github.com/meshcloud/meshcloud-docs/assets/64793818/c46e0e8b-fef9-4001-a8a6-97c607faa15a)

Open for any suggestion, as table seems to be quite bloated.