### PR TITLE
fix: Wrong branch name resulting in wrong robots

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,7 +9,7 @@ frontend:
       commands:
         - yarn build
         - |
-          if [[ $AWS_BRANCH = main ]]; then
+          if [[ $AWS_BRANCH = master ]]; then
               cp robots.main.txt build/meshcloud-docs/robots.txt
           else
               cp robots.develop.txt build/meshcloud-docs/robots.txt


### PR DESCRIPTION
https://docs.meshcloud.io/robots.txt has the wrong one (develop)

For this repo our `main` branch is still called `master`.