### PR TITLE
fix: Wrong file name for robots.txt

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -10,7 +10,7 @@ frontend:
         - yarn build
         - |
           if [[ $AWS_BRANCH = master ]]; then
-              cp robots.main.txt build/meshcloud-docs/robots.txt
+              cp robots.master.txt build/meshcloud-docs/robots.txt
           else
               cp robots.develop.txt build/meshcloud-docs/robots.txt
           fi


### PR DESCRIPTION
I gues this also proves the `AWS_BRANCH` was wrong before