### PR TITLE
fix: fix broken link in metering

### DIFF
--- a/docs/meshcloud.project-metering.md
+++ b/docs/meshcloud.project-metering.md
@@ -111,7 +111,7 @@ This export will contain the line items (see above) of all the chargeback statem
 The line item data is suitable for feeding into chargeback processing, e.g. importing it to an ERP System to transfer
 budgets between cost centers.
 
-Chargeback Statements also contain billing information per line item. Your Cloud Foundation team can [configure](meshstack.billing.md#chargeback)
+Chargeback Statements also contain billing information per line item. Your Cloud Foundation team can [configure](meshstack.billing-configuration.md)
 which information meshStack should include as billing information in chargeback statements.
 
 > Cloud Foundation teams typically configure billing information to payment method name, identifier, expiration date and amount as well as any workspace tags, project tags and payment method tags.


### PR DESCRIPTION
the current link seems broken: at [this page](https://docs.meshcloud.io/docs/meshcloud.project-metering.html#exporting-chargeback-statements), when I click here:

![image](https://github.com/meshcloud/meshcloud-docs/assets/14194284/56991d36-dcaf-4bb5-8926-1ad671def3e4)

Then I get this page:

![image](https://github.com/meshcloud/meshcloud-docs/assets/14194284/87a5054f-2367-43cf-9ba7-7123cf350e4e)

So I changed it that it redirects to this page instead:

![image](https://github.com/meshcloud/meshcloud-docs/assets/14194284/cc148731-2d86-44df-a131-9d4db9c8cbd3)
