### PR TITLE
docs: remove mention of old meshStack version

### DIFF
--- a/docs/meshcloud.metadata-tags.md
+++ b/docs/meshcloud.metadata-tags.md
@@ -23,8 +23,6 @@ meshPanel seamlessly integrates any tags that can be set by allowing users to in
 
 Administrators can configure tags so that only [Partner users](./administration.index.md) can edit them. These tags are called **restricted tags**. End-users cannot edit restricted tags in meshPanel, but they can view them at anytime. Partner users can view and edit restricted and unrestricted tags.
 
-**Note**: In all meshStack versions prior to v7.52.0, partners are not able to edit unrestricted tags.
-
 The [administration documentation](./administration.index.md) provides further details on how partner users can edit restricted tags.
 
 ## Immutable tags


### PR DESCRIPTION
This feature has been rolled out a long time ago so this notice is no longer relevant to users.