### PR TITLE
fix: fix broken link

### DIFF
--- a/docs/meshstack.how-to.change-workspace-owner.md
+++ b/docs/meshstack.how-to.change-workspace-owner.md
@@ -13,7 +13,7 @@ If the meshWorkspace has two Workspace Owners set, you need to follow all three 
 
 ## Step 1: Create a meshObjectCollection
 
-Follow [API docs]((api/#mesh_object_collection_create) to create a meshObjectCollection.
+Follow [API docs](/api/#mesh_object_collection_create) to create a meshObjectCollection.
 
 ```sh
 curl --location --request POST 'https://backend-url/api/meshobjectcollections' \


### PR DESCRIPTION
Fix broken link in the section "How to change the Workspace Owner of a
meshWorkspace via API"

this is how it currently looks like on https://docs.meshcloud.io/docs/meshstack.how-to.change-workspace-owner.html:

![image](https://github.com/user-attachments/assets/732715d9-8efb-4815-b66c-0067fb6d24fa)

this is how it looks like with the fix:
![image](https://github.com/user-attachments/assets/ec22c706-33c8-46bf-9f9a-955f4b6220fc)
