### PR TITLE
feat: add info about when to process chargebacks

### DIFF
--- a/docs/meshcloud.project-metering.md
+++ b/docs/meshcloud.project-metering.md
@@ -75,6 +75,13 @@ This export will contain the line items (see above) of all the chargeback statem
 The line item data is suitable for feeding into chargeback processing, e.g. importing it to an ERP System to transfer
 budgets between cost centers.
 
+For customers that export chargeback statements on a monthly basis, the following recommendation applies:
+Chargeback statements of the previous month should be processed not earlier than the `finalizeReportsAfterDays` setting,
+plus 2 days, at 7 am (German local time). For example, if `finalizeReportsAfterDays` is set to 4
+(which is the default), then chargeback statements of May can be processed starting at June 6th, 7am.
+If you don't know the configuration of the `finalizeReportsAfterDays` setting in your meshStack, please contact your
+platform team.
+
 Chargeback Statements also contain billing information per line item. Your platform team can 
 [configure](meshstack.billing-configuration.md)
 which information meshStack should include as billing information in chargeback statements.
@@ -83,13 +90,6 @@ which information meshStack should include as billing information in chargeback 
 > expiration date and amount as well as any workspace tags, project tags and payment method tags.
 
 You can review this billing information in meshPanel when opening chargeback statement. CSV Exports of chargeback statements also include the configured billing information.
-
-For customers that export chargeback statements on a monthly basis, the following recommendation applies:
-Chargeback statements of the previous month should be processed not earlier than the `finalizeReportsAfterDays` setting,
-plus 2 days, at 7 am (German local time). For example, if `finalizeReportsAfterDays` is set to 4 
-(which is the default), then chargeback statements of May can be processed starting at June 6th, 7am.
-If you don't know the configuration of the `finalizeReportsAfterDays` setting in your meshStack, please contact your
-platform team.
 
 #### Late Bills From Providers
 

--- a/docs/meshcloud.project-metering.md
+++ b/docs/meshcloud.project-metering.md
@@ -75,12 +75,21 @@ This export will contain the line items (see above) of all the chargeback statem
 The line item data is suitable for feeding into chargeback processing, e.g. importing it to an ERP System to transfer
 budgets between cost centers.
 
-Chargeback Statements also contain billing information per line item. Your Cloud Foundation team can [configure](meshstack.billing-configuration.md)
+Chargeback Statements also contain billing information per line item. Your platform team can 
+[configure](meshstack.billing-configuration.md)
 which information meshStack should include as billing information in chargeback statements.
 
-> Cloud Foundation teams typically configure billing information to payment method name, identifier, expiration date and amount as well as any workspace tags, project tags and payment method tags.
+> Platform teams typically configure billing information to payment method name, identifier, 
+> expiration date and amount as well as any workspace tags, project tags and payment method tags.
 
 You can review this billing information in meshPanel when opening chargeback statement. CSV Exports of chargeback statements also include the configured billing information.
+
+For customers that export chargeback statements on a monthly basis, the following recommendation applies:
+Chargeback statements of the previous month should be processed not earlier than the `finalizeReportsAfterDays` setting,
+plus 2 days, at 7 am (German local time). For example, if `finalizeReportsAfterDays` is set to 4 
+(which is the default), then chargeback statements of May can be processed starting at June 6th, 7am.
+If you don't know the configuration of the `finalizeReportsAfterDays` setting in your meshStack, please contact your
+platform team.
 
 #### Late Bills From Providers
 

--- a/docs/meshcloud.project-metering.md
+++ b/docs/meshcloud.project-metering.md
@@ -76,11 +76,10 @@ The line item data is suitable for feeding into chargeback processing, e.g. impo
 budgets between cost centers.
 
 For customers who export chargeback statements on a monthly basis, the following recommendation applies:
-Chargeback statements of the previous month should be processed no earlier than the `finalizeReportsAfterDays` setting
-plus 2 days, at 7 a.m. (German local time). For example, if `finalizeReportsAfterDays` is set to 4
-(the default), then chargeback statements of May can be processed starting on June 6th, 7 a.m.
-If you are unsure about the configuration of the `finalizeReportsAfterDays` setting in your meshStack, please contact your
-platform team.
+chargeback statements of the previous month should be processed no earlier than one day after the configured finalization date,
+at 7 a.m. (German local time). By default, chargeback statements are finalized at the 6th of a month, therefore,
+they can be processed starting at the 7th of a month at 7 a.m.
+If you are unsure about the configuration of the finalization day of chargebacks in your meshStack, please contact our support team.
 
 Chargeback Statements also contain billing information per line item. Your platform team can 
 [configure](meshstack.billing-configuration.md)

--- a/docs/meshcloud.project-metering.md
+++ b/docs/meshcloud.project-metering.md
@@ -75,11 +75,11 @@ This export will contain the line items (see above) of all the chargeback statem
 The line item data is suitable for feeding into chargeback processing, e.g. importing it to an ERP System to transfer
 budgets between cost centers.
 
-For customers that export chargeback statements on a monthly basis, the following recommendation applies:
-Chargeback statements of the previous month should be processed not earlier than the `finalizeReportsAfterDays` setting,
-plus 2 days, at 7 am (German local time). For example, if `finalizeReportsAfterDays` is set to 4
-(which is the default), then chargeback statements of May can be processed starting at June 6th, 7am.
-If you don't know the configuration of the `finalizeReportsAfterDays` setting in your meshStack, please contact your
+For customers who export chargeback statements on a monthly basis, the following recommendation applies:
+Chargeback statements of the previous month should be processed no earlier than the `finalizeReportsAfterDays` setting
+plus 2 days, at 7 a.m. (German local time). For example, if `finalizeReportsAfterDays` is set to 4
+(the default), then chargeback statements of May can be processed starting on June 6th, 7 a.m.
+If you are unsure about the configuration of the `finalizeReportsAfterDays` setting in your meshStack, please contact your
 platform team.
 
 Chargeback Statements also contain billing information per line item. Your platform team can 


### PR DESCRIPTION
CU-86c15vwp3

I've renamed "cloud foundation team'" to "platform team" in some cases, here's the related discussion: https://meshcloud.slack.com/archives/CSLGLMN73/p1736507492578749

Also note that I didn't explicitly describe the behavior that it can happen that the chargeback is first finalized, and then updated by a new chargeback (due to our cleanup job), because I was not sure how to describe this both concisely and correctly. And imho, a short text that gives the customer clear instructions on what to do is more valuable than a huge wall of text that is hard to understand.

But if you have a suggestion on how to describe this without overwhelming the customer with too many details, I can add it.