### PR TITLE
Replace term meshcloud with meshStack

### DIFF
--- a/docs/meshcloud.platforms.md
+++ b/docs/meshcloud.platforms.md
@@ -3,7 +3,7 @@ id: meshcloud.platforms
 title: meshPlatforms
 ---
 
-At the heart of a meshcloud are the cloud platforms that provide cloud services and resources to users.
+At the heart of a meshStack are the cloud platforms that provide cloud services and resources to users.
 
 ## meshPlatforms
 
@@ -12,13 +12,13 @@ The following terms relate to cloud platforms:
 - platform-type describes the type of a cloud platform, e.g. OpenStack, Cloud Foundry or AWS.
 - meshPlatform to describe a particular deployment of such a cloud platform.
 
-For example, meshstack can manage two, fully isolated OpenStack deployments located in different
+For example, meshStack can manage two, fully isolated OpenStack deployments located in different
 regions in the same meshcloud. While they are both of the same platform-type OpenStack, they each
 are individual meshPlatforms.
 
 ## meshLocations
 
-In a meshcloud, cloud meshPlatforms can be grouped by **meshLocation**.
+In a meshStack, cloud meshPlatforms can be grouped by **meshLocation**.
 Locations are free-form but they are typically used to help users identify the geographic datacenter
 location as well as identify the party that is responsible for managing the cloud meshPlatforms
 in this meshLocation. For example, this could be an internal IT division that manages private clouds or


### PR DESCRIPTION
meshcloud term is wrongly used to designate meshStack platform.