### PR TITLE
chore: Move some sidebar items around

### DIFF
--- a/docs/administration.index.md
+++ b/docs/administration.index.md
@@ -1,6 +1,6 @@
 ---
 id: administration.index
-title: Overview
+title: Administration Roles
 ---
 
 Partners Users have access to the so called **Administration Area**. The administration area enables partner users to manage their child [meshWorkspace](./meshcloud.workspace.md) accounts within the meshcloud platform.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -35,18 +35,18 @@
     ]
   },
   "meshstack": {
-    "Governance": [
-      "meshstack.index",
-      "meshstack.replication-configuration",
-      "meshstack.metadata-tags",
-      "meshstack.onboarding",
-      "meshstack.customizing"
+    "Getting Started": [
+      "meshstack.how-to.get-started-with-meshstack",
+      "meshstack.building-aws-quickstart-guide"
     ],
-    "Administration": [
+    "Concepts": [
+      "meshstack.index",
       "administration.index",
+      "meshstack.onboarding",
       "administration.workspaces",
       "administration.projects",
       "administration.tenants",
+      "meshstack.replication-configuration",
       "administration.delete-tenants",
       "administration.users",
       "administration.platforms",
@@ -55,12 +55,14 @@
       "administration.service-brokers",
       "administration.analytics",
       "administration.emergency-users",
+      "meshstack.metadata-tags",
       "administration.policies",
       "administration.unmanaged-tenants",
       "administration.meshstack-settings",
       "administration.workspace-services",
       "administration.apiusers",
       "administration.dns",
+      "meshstack.customizing",
       "administration.product-feedback-collection"
     ],
     "Identity & Access": [
@@ -76,8 +78,7 @@
       "meshstack.building-blocks.private-runners",
       "meshstack.building-blocks.meshStack-http-backend",
       "meshstack.building-blocks.permission-delegation-aws",
-      "meshstack.building-pipeline-integration",
-      "meshstack.building-aws-quickstart-guide"
+      "meshstack.building-pipeline-integration"
     ],
     "Metering & Billing": [
       "meshstack.billing",
@@ -140,7 +141,6 @@
       "faq"
     ],
     "Guides": [
-      "meshstack.how-to.get-started-with-meshstack",
       "meshstack.how-to.integrate-meshplatform",
       "meshstack.how-to.integrate-meshplatform-aws-manually",
       "meshstack.how-to.integrate-meshplatform-azure-manually",


### PR DESCRIPTION
I created a new "Getting Started" section at the top and moved the new get started guide + AWS S3 quickstart in there. I also plan to add the "First platform experience" in there too.

I also renamed the "Adminstration > Overview" page to "Administration > Administration Roles" as that is the only thing that page talks about.

And then I removed the "Governance" section and put all that stuff into the "Administration" section.

<img width="1904" alt="image" src="https://github.com/user-attachments/assets/26636055-a2c0-482a-b5ba-d68939c675b0" />
