### PR TITLE
Navbar link to terraform

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -124,6 +124,11 @@ const config: Config = {
           label: 'API Docs',
         },
         {
+          href: 'https://registry.terraform.io/providers/meshcloud/meshstack/latest/docs',
+          position: 'right',
+          label: 'meshStack Terraform Docs'
+        },
+        {
           to: '/blog',
           label: 'Release Notes',
           position: 'right'


### PR DESCRIPTION
Add a link to meshstack terraform documentation in the navbar