### PR TITLE
fix: Fix scim meshfed backend url

### DIFF
--- a/docs/settings/user-group-provisioning.md
+++ b/docs/settings/user-group-provisioning.md
@@ -116,7 +116,7 @@ To set up the provisioning on AAD side, have a look at [Microsoft's guideline](h
 2. Create a new non-gallery Enterprise Application (EA) in your AAD that is dedicated to the provisioning. A step-by-step guide is available [here](https://docs.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#getting-started).
 3. In the EA set up the meshStack endpoint as target API:
    1. Go to the "Provisioning" section and then to "Admin Credentials"-
-   2. Use your meshStack's backend URL as endpoint: `https://meshfed.<meshStack>/api/scim/v2/`.
+   2. Use your meshStack's backend URL as endpoint: `https://api.<meshStack>/api/scim/v2/` (in older meshStacks you may need to use `meshfed` or `federation` instead of `api` in the URL).
    3. Create an [API user](../guides/core/how-to-manage-api-users.md) with permission `Use all SCIM endpoints provided by meshStack` in meshStack.
    ![Create API User](/assets/aad-user-and-group-sync.png)
    4. Set the base64 encoded Basic Auth Credentials as "Secret Token".


### PR DESCRIPTION
fyi, I also checked for other occurrences of the wrong url, but didn't find any. So this was the only place where meshfed.* was used